### PR TITLE
feat(loans): provide loan applications report for manual review

### DIFF
--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/gateways/ApplicationRepository.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/gateways/ApplicationRepository.java
@@ -1,10 +1,21 @@
 package co.com.pragma.crediya.model.loan.gateways;
 
 import co.com.pragma.crediya.model.loan.Application;
+import co.com.pragma.crediya.model.loan.report.ApplicationReport;
+import co.com.pragma.crediya.model.loan.report.LoanApplicationFilter;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface ApplicationRepository {
 
     Mono<Application> save(Application application);
+
+    Flux<ApplicationReport> findApplicationsReport(int limit, int page);
+
+    Mono<Long> countLoanApplications();
+
+    Flux<ApplicationReport> findApplicationsReport(LoanApplicationFilter filter);
+
+    Mono<Long> countLoanApplications(LoanApplicationFilter filter);
 
 }

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/report/ApplicationReport.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/report/ApplicationReport.java
@@ -1,0 +1,14 @@
+package co.com.pragma.crediya.model.loan.report;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record ApplicationReport(
+        UUID id,
+        BigDecimal amount,
+        int term,
+        String email,
+        String type,
+        BigDecimal interestRate,
+        String status) {
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/report/CustomerApplication.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/report/CustomerApplication.java
@@ -1,0 +1,14 @@
+package co.com.pragma.crediya.model.loan.report;
+
+import java.math.BigDecimal;
+
+public record CustomerApplication(
+        String email,
+        BigDecimal baseSalary,
+        BigDecimal totalMonthlyDebt,
+        String type,
+        BigDecimal amount,
+        int term,
+        BigDecimal interestRate,
+        String status) {
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/report/LoanApplicationFilter.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/report/LoanApplicationFilter.java
@@ -1,0 +1,26 @@
+package co.com.pragma.crediya.model.loan.report;
+
+import java.math.BigDecimal;
+import java.util.Set;
+
+public record LoanApplicationFilter(
+        Set<String> statuses,
+        BigDecimal minAmount,
+        BigDecimal maxAmount,
+        Integer minTerm,
+        Integer maxTerm,
+        String email,
+        String loanType,
+        int limit,
+        int page) {
+
+    public boolean onlyPagination() {
+        return (statuses == null || statuses.isEmpty()) &&
+                minAmount == null &&
+                maxAmount == null &&
+                minTerm == null &&
+                maxTerm == null &&
+                email == null &&
+                loanType == null;
+    }
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/report/LoanApplicationsReport.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/report/LoanApplicationsReport.java
@@ -1,0 +1,8 @@
+package co.com.pragma.crediya.model.loan.report;
+
+import java.util.List;
+
+public record LoanApplicationsReport(
+        List<CustomerApplication> data,
+        long totalItems) {
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/user/User.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/user/User.java
@@ -1,6 +1,9 @@
 package co.com.pragma.crediya.model.user;
 
+import java.math.BigDecimal;
+
 public record User(
         String identificationNumber,
-        String email) {
+        String email,
+        BigDecimal baseSalary) {
 }

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/user/gateways/UserPort.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/user/gateways/UserPort.java
@@ -3,8 +3,11 @@ package co.com.pragma.crediya.model.user.gateways;
 import co.com.pragma.crediya.model.user.User;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
+import java.util.Set;
+
 public interface UserPort {
 
-    Mono<User> getUserByIdentificationNumber(String identificationNumber);
+    Mono<List<User>> getUsersByEmails(Set<String> emails);
 
 }

--- a/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/ApplicationUseCase.java
+++ b/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/ApplicationUseCase.java
@@ -2,7 +2,6 @@ package co.com.pragma.crediya.usecase.loan;
 
 import co.com.pragma.crediya.model.common.constants.DomainConstants;
 import co.com.pragma.crediya.model.jwt.Jwt;
-import co.com.pragma.crediya.model.jwt.gateways.JwtProviderPort;
 import co.com.pragma.crediya.model.loan.Application;
 import co.com.pragma.crediya.model.loan.Status;
 import co.com.pragma.crediya.model.loan.Type;
@@ -25,7 +24,6 @@ import java.util.StringJoiner;
 public record ApplicationUseCase(TypeRepository typeRepository,
                                  StatusRepository statusRepository,
                                  ApplicationRepository applicationRepository,
-                                 JwtProviderPort jwtProviderPort,
                                  LoggerPort logger,
                                  TransactionalPort transactionalPort) {
 

--- a/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/report/ApplicationReportUseCase.java
+++ b/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/report/ApplicationReportUseCase.java
@@ -1,0 +1,103 @@
+package co.com.pragma.crediya.usecase.loan.report;
+
+import co.com.pragma.crediya.model.loan.report.ApplicationReport;
+import co.com.pragma.crediya.model.loan.report.LoanApplicationFilter;
+import co.com.pragma.crediya.model.loan.gateways.ApplicationRepository;
+import co.com.pragma.crediya.model.loan.report.CustomerApplication;
+import co.com.pragma.crediya.model.loan.report.LoanApplicationsReport;
+import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
+import co.com.pragma.crediya.model.user.User;
+import co.com.pragma.crediya.model.user.gateways.UserPort;
+import co.com.pragma.crediya.usecase.loan.utils.ApplicationCalculatorUtils;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record ApplicationReportUseCase(ApplicationRepository applicationRepository,
+                                       UserPort userPort,
+                                       LoggerPort logger) {
+
+    public Mono<LoanApplicationsReport> getLoanApplicationsReport(LoanApplicationFilter filter) {
+        logger.info("Get loan applications report with filters: {}", filter);
+
+        Mono<List<ApplicationReport>> reportsMono;
+        Mono<Long> countMono;
+
+        if (filter.onlyPagination()) {
+            reportsMono = applicationRepository
+                    .findApplicationsReport(filter.limit(), filter.page())
+                    .collectList();
+            countMono = applicationRepository.countLoanApplications();
+        } else {
+            reportsMono = applicationRepository
+                    .findApplicationsReport(filter)
+                    .collectList();
+            countMono = applicationRepository.countLoanApplications(filter);
+        }
+
+        return Mono.zip(reportsMono, countMono)
+                .flatMap(tuple -> {
+                    List<ApplicationReport> results = tuple.getT1();
+                    long count = tuple.getT2();
+
+                    if (results.isEmpty()) {
+                        logger.info("No results found for the given filters parameters");
+
+                        return Mono.just(new LoanApplicationsReport(List.of(), count));
+                    }
+
+                    Set<String> emails = results.stream()
+                            .map(ApplicationReport::email)
+                            .collect(Collectors.toSet());
+
+                    logger.info("Collected emails from reports: {}", emails);
+
+                    return userPort.getUsersByEmails(emails)
+                            .map(users -> {
+                                Map<String, User> userMap = users.stream()
+                                        .collect(Collectors.toMap(User::email, u -> u));
+
+                                Map<String, BigDecimal> debtsByEmail = results.stream()
+                                        .collect(Collectors.groupingBy(
+                                                ApplicationReport::email,
+                                                Collectors.reducing(
+                                                        BigDecimal.ZERO,
+                                                        r -> ApplicationCalculatorUtils.calculateMonthlyPayment(
+                                                                r.amount(),
+                                                                r.interestRate(),
+                                                                r.term()
+                                                        ),
+                                                        BigDecimal::add
+                                                )
+                                        ));
+
+                                return results.stream()
+                                        .map(r -> {
+                                            User user = userMap.get(r.email());
+                                            BigDecimal baseSalary = user != null ? user.baseSalary() : BigDecimal.ZERO;
+                                            BigDecimal totalMonthlyDebt = debtsByEmail.getOrDefault(r.email(), BigDecimal.ZERO);
+
+                                            logger.info("Preparing CustomerApplication for email: {}", r.email());
+
+                                            return new CustomerApplication(
+                                                    r.email(),
+                                                    baseSalary,
+                                                    totalMonthlyDebt,
+                                                    r.type(),
+                                                    r.amount(),
+                                                    r.term(),
+                                                    r.interestRate(),
+                                                    r.status()
+                                            );
+                                        })
+                                        .toList();
+                            })
+                            .map(data -> new LoanApplicationsReport(data, count));
+                });
+    }
+
+}

--- a/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/utils/ApplicationCalculatorUtils.java
+++ b/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/utils/ApplicationCalculatorUtils.java
@@ -1,0 +1,31 @@
+package co.com.pragma.crediya.usecase.loan.utils;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class ApplicationCalculatorUtils {
+
+    private static final int CALCULATION_SCALE = 10;
+    private static final int RESULT_SCALE = 2;
+    private static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
+
+    private ApplicationCalculatorUtils() {
+    }
+
+    public static BigDecimal calculateMonthlyPayment(BigDecimal amount, BigDecimal interestRate, int term) {
+        if (interestRate.compareTo(BigDecimal.ZERO) == 0) {
+            return amount.divide(BigDecimal.valueOf(term), RESULT_SCALE, RoundingMode.HALF_UP);
+        }
+
+        // R = (amount * interestRate) / (1 - (1 + interestRate)^(-term))
+        BigDecimal numerator = amount.multiply(interestRate);
+        BigDecimal onePlusRate = BigDecimal.ONE.add(interestRate);
+        BigDecimal powerResult = onePlusRate.pow(term);
+        BigDecimal denominator = BigDecimal.ONE.subtract(
+                BigDecimal.ONE.divide(powerResult, CALCULATION_SCALE, ROUNDING_MODE)
+        );
+
+        return numerator.divide(denominator, RESULT_SCALE, ROUNDING_MODE);
+    }
+
+}

--- a/domain/usecase/src/test/java/co/com/pragma/crediya/usecase/loan/ApplicationUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/pragma/crediya/usecase/loan/ApplicationUseCaseTest.java
@@ -6,6 +6,7 @@ import co.com.pragma.crediya.model.loan.Application;
 import co.com.pragma.crediya.model.loan.Status;
 import co.com.pragma.crediya.model.loan.Type;
 import co.com.pragma.crediya.model.loan.exceptions.ApplicationValueOutOfBoundsException;
+import co.com.pragma.crediya.model.loan.exceptions.StatusNotFoundException;
 import co.com.pragma.crediya.model.loan.exceptions.TypeNotFoundException;
 import co.com.pragma.crediya.model.loan.gateways.ApplicationRepository;
 import co.com.pragma.crediya.model.loan.gateways.StatusRepository;
@@ -26,6 +27,7 @@ import reactor.test.StepVerifier;
 import java.math.BigDecimal;
 import java.util.UUID;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -64,7 +66,7 @@ class ApplicationUseCaseTest {
         when(transactionalPort.transactional(any(Mono.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
-        User loggedUser = new User("1234567890", "jhondoe@example.com");
+        User loggedUser = new User("1234567890", "jhondoe@example.com", BigDecimal.valueOf(1200000));
 
         type = new Type(UUID.randomUUID(), DomainConstants.MICROCREDIT, BigDecimal.valueOf(300000), BigDecimal.valueOf(50000000), BigDecimal.valueOf(25.00), true);
 
@@ -122,6 +124,16 @@ class ApplicationUseCaseTest {
     }
 
     @Test
+    void saveApplicationFailsWhenStatusNotFound() {
+        when(typeRepository.findByName(DomainConstants.MICROCREDIT)).thenReturn(Mono.just(type));
+        when(statusRepository.findByName(DomainConstants.DEFAULT_PENDING_STATUS)).thenReturn(Mono.empty());
+
+        StepVerifier.create(useCase.save(application, mockJwt))
+                .expectError(StatusNotFoundException.class)
+                .verify();
+    }
+
+    @Test
     void saveApplicationFailsWhenAmountOutOfRange() {
         Type restrictedType = new Type(
                 UUID.randomUUID(),
@@ -136,7 +148,11 @@ class ApplicationUseCaseTest {
         when(statusRepository.findByName(DomainConstants.DEFAULT_PENDING_STATUS)).thenReturn(Mono.just(status));
 
         StepVerifier.create(useCase.save(application, mockJwt))
-                .expectError(ApplicationValueOutOfBoundsException.class)
+                .expectErrorSatisfies(error -> {
+                    assertThat(error)
+                            .isInstanceOf(ApplicationValueOutOfBoundsException.class)
+                            .hasMessage("amount most be between 10.000.000,00 and 20.000.000,00");
+                })
                 .verify();
 
         verify(typeRepository).findByName(DomainConstants.MICROCREDIT);

--- a/domain/usecase/src/test/java/co/com/pragma/crediya/usecase/loan/report/ApplicationReportUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/pragma/crediya/usecase/loan/report/ApplicationReportUseCaseTest.java
@@ -1,0 +1,147 @@
+package co.com.pragma.crediya.usecase.loan.report;
+
+import co.com.pragma.crediya.model.loan.gateways.ApplicationRepository;
+import co.com.pragma.crediya.model.loan.report.ApplicationReport;
+import co.com.pragma.crediya.model.loan.report.CustomerApplication;
+import co.com.pragma.crediya.model.loan.report.LoanApplicationFilter;
+import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
+import co.com.pragma.crediya.model.user.User;
+import co.com.pragma.crediya.model.user.gateways.UserPort;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicationReportUseCaseTest {
+
+    @Mock
+    private ApplicationRepository applicationRepository;
+
+    @Mock
+    private UserPort userPort;
+
+    @Mock
+    private LoggerPort logger;
+
+    @InjectMocks
+    private ApplicationReportUseCase useCase;
+
+    private LoanApplicationFilter paginationFilter;
+
+    private LoanApplicationFilter filter;
+
+    private ApplicationReport report1;
+
+    private ApplicationReport report2;
+
+    private User user;
+
+    private final String email = "jhon.doe@example.com";
+
+    @BeforeEach
+    void setUp() {
+        paginationFilter = new LoanApplicationFilter(null, null, null, null, null, null, null, 10, 0);
+
+        filter = new LoanApplicationFilter(Set.of("APPROVED"), BigDecimal.valueOf(1000), BigDecimal.valueOf(5000), 6, 24, email, "MICROCREDIT", 10, 0);
+
+        report1 = new ApplicationReport(UUID.randomUUID(), BigDecimal.valueOf(2000), 12, email, "MICROCREDIT", BigDecimal.valueOf(2), "APPROVED");
+
+        report2 = new ApplicationReport(UUID.randomUUID(), BigDecimal.valueOf(3000), 12, email, "MICROCREDIT", BigDecimal.valueOf(2), "APPROVED");
+
+        user = new User("12345", email, BigDecimal.valueOf(10000));
+    }
+
+    @Test
+    @DisplayName("Get loan applications report with pagination returns correct data")
+    void getLoanApplicationsReport_withPagination_shouldReturnReport() {
+        when(applicationRepository.findApplicationsReport(paginationFilter.limit(), paginationFilter.page()))
+                .thenReturn(Flux.just(report1));
+
+        when(applicationRepository.countLoanApplications()).thenReturn(Mono.just(1L));
+
+        when(userPort.getUsersByEmails(Set.of(email))).thenReturn(Mono.just(List.of(user)));
+
+        StepVerifier.create(useCase.getLoanApplicationsReport(paginationFilter))
+                .assertNext(result -> {
+                    assertThat(result.totalItems()).isEqualTo(1);
+                    assertThat(result.data()).hasSize(1);
+
+                    CustomerApplication app = result.data().getFirst();
+                    assertThat(app.email()).isEqualTo(email);
+                    assertThat(app.baseSalary()).isEqualTo(BigDecimal.valueOf(10000));
+                    assertThat(app.totalMonthlyDebt()).isGreaterThan(BigDecimal.ZERO);
+                }).verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Get loan applications report with filters returns correct data")
+    void getLoanApplicationsReport_withFilters_shouldReturnReport() {
+        when(applicationRepository.findApplicationsReport(filter)).thenReturn(Flux.just(report1));
+
+        when(applicationRepository.countLoanApplications(filter)).thenReturn(Mono.just(1L));
+
+        when(userPort.getUsersByEmails(Set.of(email))).thenReturn(Mono.just(List.of(user)));
+
+        StepVerifier.create(useCase.getLoanApplicationsReport(filter))
+                .assertNext(result -> {
+                    assertThat(result.totalItems()).isEqualTo(1);
+                    assertThat(result.data()).hasSize(1);
+
+                    CustomerApplication app = result.data().getFirst();
+                    assertThat(app.email()).isEqualTo(email);
+                    assertThat(app.baseSalary()).isEqualTo(BigDecimal.valueOf(10000));
+                    assertThat(app.status()).isEqualTo("APPROVED");
+                }).verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Get loan applications report with no results returns empty list")
+    void getLoanApplicationsReport_whenNoResults_shouldReturnEmptyList() {
+        when(applicationRepository.findApplicationsReport(any(LoanApplicationFilter.class)))
+                .thenReturn(Flux.empty());
+
+        when(applicationRepository.countLoanApplications(any(LoanApplicationFilter.class)))
+                .thenReturn(Mono.just(0L));
+
+        StepVerifier.create(useCase.getLoanApplicationsReport(filter))
+                .assertNext(result -> {
+                    assertThat(result.totalItems()).isEqualTo(0);
+                    assertThat(result.data()).isEmpty();
+                }).verifyComplete();
+    }
+
+    @Test
+    @DisplayName("Get loan applications report returns separate entries for same email")
+    void getLoanApplicationsReport_withMultipleReportsForSameEmail_shouldAggregateDebt() {
+        when(applicationRepository.findApplicationsReport(filter)).thenReturn(Flux.just(report1, report2));
+
+        when(applicationRepository.countLoanApplications(filter)).thenReturn(Mono.just(2L));
+
+        when(userPort.getUsersByEmails(Set.of(email))).thenReturn(Mono.just(List.of(user)));
+
+        StepVerifier.create(useCase.getLoanApplicationsReport(filter))
+                .assertNext(report -> {
+                    assertThat(report.totalItems()).isEqualTo(2);
+                    assertThat(report.data()).hasSize(2);
+
+                    CustomerApplication item = report.data().getFirst();
+                    assertThat(item.totalMonthlyDebt()).isGreaterThan(BigDecimal.ZERO);
+                }).verifyComplete();
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/LoanApplicationReactiveRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/LoanApplicationReactiveRepository.java
@@ -1,12 +1,46 @@
 package co.com.pragma.crediya.r2dbc;
 
 import co.com.pragma.crediya.r2dbc.entity.LoanApplicationEntity;
+import co.com.pragma.crediya.r2dbc.projection.LoanApplicationProjection;
+import co.com.pragma.crediya.r2dbc.reports.LoanApplicationCustomRepository;
+import org.springframework.data.r2dbc.repository.Query;
 import org.springframework.data.repository.query.ReactiveQueryByExampleExecutor;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.UUID;
 
 public interface LoanApplicationReactiveRepository
-        extends ReactiveCrudRepository<LoanApplicationEntity, UUID>, ReactiveQueryByExampleExecutor<LoanApplicationEntity> {
+        extends ReactiveCrudRepository<LoanApplicationEntity, UUID>,
+        ReactiveQueryByExampleExecutor<LoanApplicationEntity>,
+        LoanApplicationCustomRepository {
+
+    @Query("""
+                SELECT
+                    LA.id,
+                    LA.amount,
+                    LA.term,
+                    LA.email,
+                    T.name AS type,
+                    T.interest_rate,
+                    S.name AS status
+                FROM loan_application AS LA
+                JOIN loan_type AS T ON T.id = LA.type_id
+                JOIN loan_status S ON LA.status_id = S.id
+                WHERE
+                    S.NAME IN ('UNDER REVIEW', 'MANUAL REVIEW', 'REJECTED')
+                LIMIT :limit OFFSET :offset;
+            """)
+    Flux<LoanApplicationProjection> queryLoanApplications(int limit, int offset);
+
+    @Query("""
+                SELECT COUNT(*)
+                FROM loan_application AS LA
+                JOIN loan_type AS T ON T.id = LA.type_id
+                JOIN loan_status S ON LA.status_id = S.id
+                WHERE S.name IN ('UNDER REVIEW', 'MANUAL REVIEW', 'REJECTED')
+            """)
+    Mono<Long> countLoanApplications();
 
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/LoanApplicationRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/LoanApplicationRepositoryAdapter.java
@@ -1,9 +1,12 @@
 package co.com.pragma.crediya.r2dbc;
 
 import co.com.pragma.crediya.model.loan.Application;
+import co.com.pragma.crediya.model.loan.report.ApplicationReport;
+import co.com.pragma.crediya.model.loan.report.LoanApplicationFilter;
 import co.com.pragma.crediya.model.loan.gateways.ApplicationRepository;
 import co.com.pragma.crediya.r2dbc.mapper.LoanApplicationMapper;
 import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Repository
@@ -23,4 +26,29 @@ public class LoanApplicationRepositoryAdapter implements ApplicationRepository {
         return loanApplicationReactiveRepository.save(loanApplicationMapper.toEntity(application))
                 .map(loanApplicationMapper::toDomain);
     }
+
+    @Override
+    public Flux<ApplicationReport> findApplicationsReport(int limit, int page) {
+        int offset = (page - 1) * limit;
+
+        return loanApplicationReactiveRepository.queryLoanApplications(limit, offset)
+                .map(loanApplicationMapper::toDomain);
+    }
+
+    @Override
+    public Mono<Long> countLoanApplications() {
+        return loanApplicationReactiveRepository.countLoanApplications();
+    }
+
+    @Override
+    public Flux<ApplicationReport> findApplicationsReport(LoanApplicationFilter filter) {
+        return loanApplicationReactiveRepository.findLoanApplications(filter)
+                .map(loanApplicationMapper::toDomain);
+    }
+
+    @Override
+    public Mono<Long> countLoanApplications(LoanApplicationFilter filter) {
+        return loanApplicationReactiveRepository.countLoanApplications(filter);
+    }
+
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/mapper/LoanApplicationMapper.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/mapper/LoanApplicationMapper.java
@@ -1,7 +1,9 @@
 package co.com.pragma.crediya.r2dbc.mapper;
 
 import co.com.pragma.crediya.model.loan.Application;
+import co.com.pragma.crediya.model.loan.report.ApplicationReport;
 import co.com.pragma.crediya.r2dbc.entity.LoanApplicationEntity;
+import co.com.pragma.crediya.r2dbc.projection.LoanApplicationProjection;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -12,6 +14,8 @@ public interface LoanApplicationMapper {
     @Mapping(target = "type", ignore = true)
     @Mapping(target = "status", ignore = true)
     Application toDomain(LoanApplicationEntity loanApplicationEntity);
+
+    ApplicationReport toDomain(LoanApplicationProjection loanApplicationProjection);
 
     @Mapping(source = "type.id", target = "typeId")
     @Mapping(source = "status.id", target = "statusId")

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/projection/LoanApplicationProjection.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/projection/LoanApplicationProjection.java
@@ -1,0 +1,14 @@
+package co.com.pragma.crediya.r2dbc.projection;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record LoanApplicationProjection(
+        UUID id,
+        BigDecimal amount,
+        int term,
+        String email,
+        String type,
+        BigDecimal interestRate,
+        String status) {
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/reports/LoanApplicationCustomRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/reports/LoanApplicationCustomRepository.java
@@ -1,0 +1,15 @@
+package co.com.pragma.crediya.r2dbc.reports;
+
+import co.com.pragma.crediya.model.loan.report.LoanApplicationFilter;
+import co.com.pragma.crediya.r2dbc.projection.LoanApplicationProjection;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface LoanApplicationCustomRepository {
+
+    Flux<LoanApplicationProjection> findLoanApplications(LoanApplicationFilter filter);
+
+    Mono<Long> countLoanApplications(LoanApplicationFilter filter);
+
+}
+

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/reports/LoanApplicationCustomRepositoryImpl.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/reports/LoanApplicationCustomRepositoryImpl.java
@@ -1,0 +1,89 @@
+package co.com.pragma.crediya.r2dbc.reports;
+
+import co.com.pragma.crediya.model.loan.report.LoanApplicationFilter;
+import co.com.pragma.crediya.r2dbc.projection.LoanApplicationProjection;
+import co.com.pragma.crediya.r2dbc.reports.utils.LoanApplicationQueryBuilder;
+import co.com.pragma.crediya.r2dbc.reports.utils.SqlWithParams;
+import lombok.RequiredArgsConstructor;
+import org.springframework.r2dbc.core.DatabaseClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+public class LoanApplicationCustomRepositoryImpl implements LoanApplicationCustomRepository {
+
+    private final DatabaseClient client;
+
+    private final LoanApplicationQueryBuilder builder = new LoanApplicationQueryBuilder();
+
+    @Override
+    public Flux<LoanApplicationProjection> findLoanApplications(LoanApplicationFilter filter) {
+        SqlWithParams where = builder.buildWhereClause(filter);
+
+        String sql = """
+                    SELECT
+                        LA.id,
+                        LA.amount,
+                        LA.term,
+                        LA.email,
+                        T.name AS type,
+                        T.interest_rate,
+                        S.name AS status
+                    FROM loan_application AS LA
+                    JOIN loan_type AS T ON T.id = LA.type_id
+                    JOIN loan_status S ON LA.status_id = S.id
+                """ + where.sql() + " LIMIT :limit OFFSET :offset";
+
+        Map<String, Object> params = new HashMap<>(where.params());
+        params.put("limit", filter.limit());
+
+        int offset = (filter.page() - 1) * filter.limit();
+        params.put("offset", offset);
+
+        DatabaseClient.GenericExecuteSpec spec = client.sql(sql);
+        for (Map.Entry<String, Object> entry : params.entrySet()) {
+            spec = spec.bind(entry.getKey(), entry.getValue());
+        }
+
+        return spec
+                .map((row, meta) -> new LoanApplicationProjection(
+                        row.get("id", UUID.class),
+                        row.get("amount", BigDecimal.class),
+                        row.get("term", Integer.class),
+                        row.get("email", String.class),
+                        row.get("type", String.class),
+                        row.get("interest_rate", BigDecimal.class),
+                        row.get("status", String.class)
+                ))
+                .all();
+    }
+
+    @Override
+    public Mono<Long> countLoanApplications(LoanApplicationFilter filter) {
+        SqlWithParams where = builder.buildWhereClause(filter);
+
+        String sql = """
+                    SELECT
+                        COUNT(*)
+                    FROM loan_application AS LA
+                    JOIN loan_type AS T ON T.id = LA.type_id
+                    JOIN loan_status S ON LA.status_id = S.id
+                """ + where.sql();
+
+        Map<String, Object> params = new HashMap<>(where.params());
+
+        DatabaseClient.GenericExecuteSpec spec = client.sql(sql);
+        for (Map.Entry<String, Object> entry : params.entrySet()) {
+            spec = spec.bind(entry.getKey(), entry.getValue());
+        }
+
+        return spec.map((row, meta) -> row.get(0, Long.class))
+                .one();
+    }
+
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/reports/utils/LoanApplicationQueryBuilder.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/reports/utils/LoanApplicationQueryBuilder.java
@@ -1,0 +1,51 @@
+package co.com.pragma.crediya.r2dbc.reports.utils;
+
+import co.com.pragma.crediya.model.loan.report.LoanApplicationFilter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LoanApplicationQueryBuilder {
+
+    public SqlWithParams buildWhereClause(LoanApplicationFilter filter) {
+        StringBuilder where = new StringBuilder(" WHERE 1=1 ");
+        Map<String, Object> params = new HashMap<>();
+
+        if (filter.statuses() != null && !filter.statuses().isEmpty()) {
+            where.append(" AND S.name IN (:statuses)");
+            params.put("statuses", filter.statuses());
+        }
+
+        if (filter.minAmount() != null) {
+            where.append(" AND LA.amount >= :minAmount");
+            params.put("minAmount", filter.minAmount());
+        }
+
+        if (filter.maxAmount() != null) {
+            where.append(" AND LA.amount <= :maxAmount");
+            params.put("maxAmount", filter.maxAmount());
+        }
+
+        if (filter.minTerm() != null) {
+            where.append(" AND LA.term >= :minTerm");
+            params.put("minTerm", filter.minTerm());
+        }
+
+        if (filter.maxTerm() != null) {
+            where.append(" AND LA.term <= :maxTerm");
+            params.put("maxTerm", filter.maxTerm());
+        }
+
+        if (filter.email() != null) {
+            where.append(" AND LA.email = :email");
+            params.put("email", filter.email());
+        }
+
+        if (filter.loanType() != null) {
+            where.append(" AND T.name = :loanType");
+            params.put("loanType", filter.loanType());
+        }
+
+        return new SqlWithParams(where.toString(), params);
+    }
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/reports/utils/SqlWithParams.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/reports/utils/SqlWithParams.java
@@ -1,0 +1,6 @@
+package co.com.pragma.crediya.r2dbc.reports.utils;
+
+import java.util.Map;
+
+public record SqlWithParams(String sql, Map<String, Object> params) {
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/resources/db/migration/V1__create_loan_type_and_loan_application_and_loan_status_tables.sql
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/resources/db/migration/V1__create_loan_type_and_loan_application_and_loan_status_tables.sql
@@ -36,6 +36,7 @@ VALUES ('PERSONAL LOAN', 500000, 100000000, 18.50, TRUE),
 
 INSERT INTO loan_status (name, description)
 VALUES ('UNDER REVIEW', 'Application received, under evaluation'),
+       ('MANUAL REVIEW', 'Application requires manual verification by an advisor'),
        ('APPROVED', 'Loan application approved'),
        ('REJECTED', 'Loan application rejected'),
        ('CANCELLED', 'Application cancelled by the client or the system');

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/pragma/crediya/r2dbc/LoanApplicationRepositoryAdapterTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/pragma/crediya/r2dbc/LoanApplicationRepositoryAdapterTest.java
@@ -52,7 +52,9 @@ class LoanApplicationRepositoryAdapterTest {
     @Test
     void saveApplicationSuccessfully() {
         when(mapper.toEntity(application)).thenReturn(loanApplicationEntity);
+
         when(reactiveRepository.save(loanApplicationEntity)).thenReturn(Mono.just(loanApplicationEntity));
+
         when(mapper.toDomain(loanApplicationEntity)).thenReturn(application);
 
         StepVerifier.create(adapter.save(application))
@@ -67,6 +69,7 @@ class LoanApplicationRepositoryAdapterTest {
     @Test
     void saveApplicationPropagatesError() {
         when(mapper.toEntity(application)).thenReturn(loanApplicationEntity);
+
         when(reactiveRepository.save(loanApplicationEntity)).thenReturn(Mono.error(new RuntimeException("DB error")));
 
         StepVerifier.create(adapter.save(application))
@@ -75,7 +78,9 @@ class LoanApplicationRepositoryAdapterTest {
                 .verify();
 
         verify(mapper).toEntity(application);
+
         verify(reactiveRepository).save(loanApplicationEntity);
-        verify(mapper, never()).toDomain(any());
+
+        verify(mapper, never()).toDomain(any(LoanApplicationEntity.class));
     }
 }

--- a/infrastructure/driven-adapters/rest-consumer/build.gradle
+++ b/infrastructure/driven-adapters/rest-consumer/build.gradle
@@ -4,6 +4,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
 
+    // Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+
     // Mapstruct
     implementation 'org.mapstruct:mapstruct:1.6.3'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'

--- a/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/pragma/crediya/consumer/UserServiceClient.java
+++ b/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/pragma/crediya/consumer/UserServiceClient.java
@@ -1,19 +1,21 @@
 package co.com.pragma.crediya.consumer;
 
-import co.com.pragma.crediya.consumer.dto.UserEmailResponse;
+import co.com.pragma.crediya.consumer.dto.EmailsRequest;
+import co.com.pragma.crediya.consumer.dto.UserResponse;
 import co.com.pragma.crediya.consumer.mapper.UserExternalMapper;
 import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
 import co.com.pragma.crediya.model.user.User;
-import co.com.pragma.crediya.model.user.constants.UserErrorMessages;
 import co.com.pragma.crediya.model.user.constants.UserServiceMessages;
 import co.com.pragma.crediya.model.user.exceptions.UserGatewayException;
-import co.com.pragma.crediya.model.user.exceptions.UserNotFoundException;
 import co.com.pragma.crediya.model.user.gateways.UserPort;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -26,33 +28,31 @@ public class UserServiceClient implements UserPort {
     private final UserExternalMapper userExternalMapper;
 
     @Override
-    public Mono<User> getUserByIdentificationNumber(String identificationNumber) {
+    public Mono<List<User>> getUsersByEmails(Set<String> emails) {
+        EmailsRequest request = new EmailsRequest(new ArrayList<>(emails));
+
+
         return webClient
-                .get()
-                .uri("/api/v1/users/{identificationNumber}", identificationNumber)
+                .post()
+                .uri("/api/v1/users/search")
+                .bodyValue(request)
                 .retrieve()
                 .onStatus(
-                        httpStatus -> httpStatus.isSameCodeAs(HttpStatus.NOT_FOUND),
-                        clientResponse -> {
-                            UserNotFoundException ex = new UserNotFoundException();
-                            logger.error(UserErrorMessages.USER_NOT_FOUND, ex);
-
-                            return Mono.error(ex);
-                        }
-                )
-                .onStatus(httpStatus -> httpStatus.is4xxClientError() || httpStatus.is5xxServerError(),
+                        httpStatus -> httpStatus.is4xxClientError() || httpStatus.is5xxServerError(),
                         clientResponse -> clientResponse.bodyToMono(String.class)
                                 .flatMap(error -> {
                                     UserGatewayException ex = new UserGatewayException(UserServiceMessages.RESPONSE_ERROR);
                                     logger.warn("Error from user service. Payload: {}", error);
 
                                     return Mono.error(ex);
-                                }))
-                .bodyToMono(UserEmailResponse.class)
+                                })
+                )
+                .bodyToFlux(UserResponse.class)
                 .map(userExternalMapper::toDomain)
-                .doOnSuccess(user -> logger.info("User found: {}", user.identificationNumber()))
+                .collectList()
+                .doOnSuccess(users -> logger.info("Users found: {}", users.size()))
                 .onErrorMap(
-                        ex -> !(ex instanceof UserNotFoundException || ex instanceof UserGatewayException),
+                        ex -> !(ex instanceof UserGatewayException),
                         ex -> {
                             logger.error(UserServiceMessages.COMMUNICATION_FAILED, ex);
 

--- a/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/pragma/crediya/consumer/config/RestConsumerConfig.java
+++ b/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/pragma/crediya/consumer/config/RestConsumerConfig.java
@@ -1,5 +1,6 @@
 package co.com.pragma.crediya.consumer.config;
 
+import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;
 import lombok.RequiredArgsConstructor;
@@ -8,7 +9,13 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.reactive.ClientHttpConnector;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
 
 import static io.netty.channel.ChannelOption.CONNECT_TIMEOUT_MILLIS;
@@ -20,12 +27,16 @@ public class RestConsumerConfig {
 
     private final RestConsumerProperties properties;
 
+    private final LoggerPort logger;
+
     @Bean
     public WebClient getWebClient(WebClient.Builder builder) {
         return builder
                 .baseUrl(properties.getUrl())
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, "application/json")
                 .clientConnector(getClientHttpConnector())
+                .filter(addAuthToken())
+                .filter(logRequests())
                 .build();
     }
 
@@ -38,6 +49,32 @@ public class RestConsumerConfig {
                     connection.addHandlerLast(new ReadTimeoutHandler(properties.getTimeout(), MILLISECONDS));
                     connection.addHandlerLast(new WriteTimeoutHandler(properties.getTimeout(), MILLISECONDS));
                 }));
+    }
+
+    private ExchangeFilterFunction addAuthToken() {
+        return (clientRequest, next) ->
+                ReactiveSecurityContextHolder.getContext()
+                        .map(SecurityContext::getAuthentication)
+                        .map(Authentication::getCredentials)
+                        .cast(String.class)
+                        .map(token -> ClientRequest.from(clientRequest)
+                                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
+                                .build())
+                        .defaultIfEmpty(clientRequest)
+                        .flatMap(next::exchange)
+                        .onErrorResume(ex -> {
+                            logger.warn("Could not get JWT token, proceeding without auth header: {}", ex.getMessage());
+
+                            return next.exchange(clientRequest);
+                        });
+    }
+
+    private ExchangeFilterFunction logRequests() {
+        return ExchangeFilterFunction.ofRequestProcessor(request -> {
+            logger.info("Outbound Request: {} {}", request.method(), request.url());
+
+            return Mono.just(request);
+        });
     }
 
 }

--- a/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/pragma/crediya/consumer/dto/EmailsRequest.java
+++ b/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/pragma/crediya/consumer/dto/EmailsRequest.java
@@ -1,0 +1,7 @@
+package co.com.pragma.crediya.consumer.dto;
+
+import java.util.List;
+
+public record EmailsRequest(
+        List<String> emails) {
+}

--- a/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/pragma/crediya/consumer/dto/UserResponse.java
+++ b/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/pragma/crediya/consumer/dto/UserResponse.java
@@ -5,14 +5,16 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class UserEmailResponse {
+public class UserResponse {
 
     private String email;
 
-    private String identificationNumber;
+    private BigDecimal baseSalary;
 
 }

--- a/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/pragma/crediya/consumer/mapper/UserExternalMapper.java
+++ b/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/pragma/crediya/consumer/mapper/UserExternalMapper.java
@@ -1,12 +1,14 @@
 package co.com.pragma.crediya.consumer.mapper;
 
-import co.com.pragma.crediya.consumer.dto.UserEmailResponse;
+import co.com.pragma.crediya.consumer.dto.UserResponse;
 import co.com.pragma.crediya.model.user.User;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface UserExternalMapper {
 
-    User toDomain(UserEmailResponse userEmailResponse);
+    @Mapping(target = "identificationNumber", ignore = true)
+    User toDomain(UserResponse userResponse);
 
 }

--- a/infrastructure/driven-adapters/rest-consumer/src/test/java/co/com/pragma/crediya/consumer/UserServiceClientTest.java
+++ b/infrastructure/driven-adapters/rest-consumer/src/test/java/co/com/pragma/crediya/consumer/UserServiceClientTest.java
@@ -1,8 +1,11 @@
 package co.com.pragma.crediya.consumer;
 
+import co.com.pragma.crediya.consumer.dto.UserResponse;
 import co.com.pragma.crediya.consumer.mapper.UserExternalMapper;
 import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
 import co.com.pragma.crediya.model.user.User;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.AfterAll;
@@ -13,12 +16,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,6 +39,8 @@ class UserServiceClientTest {
 
     @Mock
     private static UserExternalMapper mapper;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeAll
     static void startMockServer() throws IOException {
@@ -54,43 +62,28 @@ class UserServiceClientTest {
     }
 
     @Test
-    void shouldReturnUserWhenApiRespondsOk() {
-        String jsonResponse = """
-                {
-                  "identificationNumber": "123456789",
-                  "email": "john@example.com"
-                }
-                """;
+    void getUsersByEmails_shouldReturnMappedUsers() throws JsonProcessingException {
+        UserResponse john = new UserResponse("john@example.com", BigDecimal.valueOf(10000));
+        UserResponse jane = new UserResponse("jane@example.com", BigDecimal.valueOf(20000));
 
         mockWebServer.enqueue(new MockResponse()
-                .setBody(jsonResponse)
+                .setBody(objectMapper.writeValueAsString(List.of(john, jane)))
                 .addHeader("Content-Type", "application/json"));
 
-        when(mapper.toDomain(any()))
+        when(mapper.toDomain(any(UserResponse.class)))
                 .thenAnswer(invocation -> {
-                    invocation.getArgument(0);
-                    return new User(
-                            "123456789",
-                            "john@example.com"
-                    );
+                    UserResponse dto = invocation.getArgument(0);
+                    return new User(null, dto.getEmail(), dto.getBaseSalary());
                 });
 
-        String userIdentificationNumber = "123456789";
-        var result = userServiceClient.getUserByIdentificationNumber(userIdentificationNumber).block();
-
-        assertThat(result).isNotNull();
-        assertThat(result.identificationNumber()).isEqualTo(userIdentificationNumber);
-        assertThat(result.email()).isEqualTo("john@example.com");
+        Set<String> emails = Set.of(john.getEmail(), jane.getEmail());
+        StepVerifier.create(userServiceClient.getUsersByEmails(emails))
+                .assertNext(users -> {
+                    assertThat(users).hasSize(2);
+                    assertThat(users.get(0).email()).isEqualTo(john.getEmail());
+                    assertThat(users.get(1).email()).isEqualTo(jane.getEmail());
+                })
+                .verifyComplete();
     }
 
-    @Test
-    void shouldHandleNotFoundGracefully() {
-        mockWebServer.enqueue(new MockResponse()
-                .setResponseCode(404)
-                .addHeader("Content-Type", "application/json"));
-
-        Mono<?> result = userServiceClient.getUserByIdentificationNumber("999");
-
-        assertThat(result.onErrorResume(e -> Mono.empty()).block()).isNull();
-    }
 }

--- a/infrastructure/driven-adapters/rest-consumer/src/test/java/co/com/pragma/crediya/consumer/config/RestConsumerConfigTest.java
+++ b/infrastructure/driven-adapters/rest-consumer/src/test/java/co/com/pragma/crediya/consumer/config/RestConsumerConfigTest.java
@@ -1,5 +1,6 @@
 package co.com.pragma.crediya.consumer.config;
 
+import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -13,12 +14,14 @@ class RestConsumerConfigTest {
 
     private RestConsumerConfig restConsumerConfig;
 
+    private LoggerPort loggerPort;
+
     @BeforeEach
     void setUp() {
         properties = new RestConsumerProperties();
         ReflectionTestUtils.setField(properties, "url", "http://localhost:8080");
         ReflectionTestUtils.setField(properties, "timeout", 5000);
-        restConsumerConfig = new RestConsumerConfig(properties);
+        restConsumerConfig = new RestConsumerConfig(properties, loggerPort);
     }
 
     @Test

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/LoanApplicationHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/LoanApplicationHandler.java
@@ -1,12 +1,17 @@
 package co.com.pragma.crediya.api;
 
 import co.com.pragma.crediya.api.config.security.SecurityUtils;
+import co.com.pragma.crediya.api.dto.CustomerApplicationsReport;
+import co.com.pragma.crediya.api.dto.ReportMetadata;
 import co.com.pragma.crediya.api.dto.SaveLoanApplicationRequest;
 import co.com.pragma.crediya.api.exceptions.EmptyRequestBodyException;
+import co.com.pragma.crediya.api.mapper.LoanApplicationRestFilterMapper;
 import co.com.pragma.crediya.api.mapper.LoanApplicationRestMapper;
 import co.com.pragma.crediya.api.validator.ReactiveValidator;
 import co.com.pragma.crediya.model.jwt.Jwt;
 import co.com.pragma.crediya.model.loan.Application;
+import co.com.pragma.crediya.model.loan.report.LoanApplicationFilter;
+import co.com.pragma.crediya.usecase.loan.report.ApplicationReportUseCase;
 import co.com.pragma.crediya.usecase.loan.ApplicationUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -22,11 +27,36 @@ public class LoanApplicationHandler {
 
     private final ApplicationUseCase applicationUseCase;
 
+    private final ApplicationReportUseCase applicationReportUseCase;
+
     private final LoanApplicationRestMapper loanApplicationMapper;
 
     private final ReactiveValidator reactiveValidator;
 
     private final SecurityUtils securityUtils;
+
+    public Mono<ServerResponse> getReport(ServerRequest request) {
+        LoanApplicationFilter filter = LoanApplicationRestFilterMapper.fromServerRequest(request);
+
+        return applicationReportUseCase.getLoanApplicationsReport(filter)
+                .map(report -> {
+                    long totalItems = report.totalItems();
+                    long totalPages = Math.ceilDiv(totalItems, filter.limit());
+                    int currentPage = filter.page();
+                    int size = report.data().size();
+
+                    ReportMetadata metadata = new ReportMetadata(totalItems, totalPages, currentPage, size);
+                    return CustomerApplicationsReport.builder()
+                            .data(report.data())
+                            .metadata(metadata)
+                            .build();
+                })
+                .flatMap(report ->
+                        ServerResponse.ok()
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .bodyValue(report)
+                );
+    }
 
     public Mono<ServerResponse> createLoanApplication(ServerRequest request) {
         return request.bodyToMono(SaveLoanApplicationRequest.class)
@@ -47,4 +77,5 @@ public class LoanApplicationHandler {
                                 .bodyValue(storedLoanApplication)
                 );
     }
+
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/RouterRest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/RouterRest.java
@@ -65,6 +65,7 @@ public class RouterRest {
     })
     public RouterFunction<ServerResponse> routerFunction(LoanApplicationHandler handler) {
         return RouterFunctions.route()
+                .GET(ApiConstants.LOAN_APPLICATIONS_PATH, handler::getReport)
                 .POST(ApiConstants.LOAN_APPLICATIONS_PATH, handler::createLoanApplication)
                 .build();
     }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/config/security/SecurityConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/config/security/SecurityConfig.java
@@ -6,6 +6,7 @@ import co.com.pragma.crediya.model.common.constants.DomainConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
@@ -28,7 +29,11 @@ public class SecurityConfig {
                 .authorizeExchange(exchangeSpec -> exchangeSpec
                         .pathMatchers(ApiConstants.PUBLIC_PATTERNS)
                         .permitAll()
-                        .pathMatchers(ApiConstants.PRIVATE_PATTERNS)
+                        .pathMatchers(HttpMethod.GET, ApiConstants.LOAN_APPLICATIONS_PATH)
+                        .hasAnyAuthority(
+                                DomainConstants.ADVISOR_ROLE
+                        )
+                        .pathMatchers(HttpMethod.POST, ApiConstants.LOAN_APPLICATIONS_PATH)
                         .hasAnyAuthority(
                                 DomainConstants.CUSTOMER_ROLE
                         )

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/config/security/SecurityUtils.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/config/security/SecurityUtils.java
@@ -20,7 +20,7 @@ public class SecurityUtils {
                 .map(jwtProviderPort::parseToken);
     }
 
-    private static Mono<String> getCurrentToken() {
+    public Mono<String> getCurrentToken() {
         return ReactiveSecurityContextHolder.getContext()
                 .map(SecurityContext::getAuthentication)
                 .map(Authentication::getCredentials)

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/constants/ApiConstants.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/constants/ApiConstants.java
@@ -15,12 +15,14 @@ public final class ApiConstants {
             "/swagger-ui.html"
     };
 
-    public static final String[] PRIVATE_PATTERNS = {
-            LOAN_APPLICATIONS_PATH + "/**"
-    };
-
     public static final String BEARER_PREFIX = "Bearer ";
 
     public static final int BEARER_PREFIX_LENGTH = BEARER_PREFIX.length();
+
+    public static final String PARAM_DELIMITER = ",";
+
+    public static final int DEFAULT_LIMIT = 5;
+
+    public static final int DEFAULT_PAGE = 1;
 
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/constants/FilterParams.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/constants/FilterParams.java
@@ -1,0 +1,26 @@
+package co.com.pragma.crediya.api.constants;
+
+public final class FilterParams {
+
+    private FilterParams() {
+    }
+
+    public static final String STATUSES = "statuses";
+
+    public static final String MIN_AMOUNT = "minAmount";
+
+    public static final String MAX_AMOUNT = "maxAmount";
+
+    public static final String MIN_TERM = "minTerm";
+
+    public static final String MAX_TERM = "maxTerm";
+
+    public static final String EMAIL = "email";
+
+    public static final String LOAN_TYPE = "loanType";
+
+    public static final String LIMIT = "limit";
+
+    public static final String PAGE = "page";
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/dto/CustomerApplicationsReport.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/dto/CustomerApplicationsReport.java
@@ -1,0 +1,21 @@
+package co.com.pragma.crediya.api.dto;
+
+import co.com.pragma.crediya.model.loan.report.CustomerApplication;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CustomerApplicationsReport {
+
+    List<CustomerApplication> data;
+
+    ReportMetadata metadata;
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/dto/ReportMetadata.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/dto/ReportMetadata.java
@@ -1,0 +1,8 @@
+package co.com.pragma.crediya.api.dto;
+
+public record ReportMetadata(
+        long totalItems,
+        long totalPages,
+        int page,
+        int size) {
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/exceptions/FieldValidationError.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/exceptions/FieldValidationError.java
@@ -16,4 +16,5 @@ public class FieldValidationError {
 
     @Schema(description = "Validation error message for the field", example = "Email format is invalid")
     private String message;
+
 }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/exceptions/InvalidQueryParamException.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/exceptions/InvalidQueryParamException.java
@@ -1,0 +1,9 @@
+package co.com.pragma.crediya.api.exceptions;
+
+public class InvalidQueryParamException extends RuntimeException {
+
+    public InvalidQueryParamException(String message) {
+        super(message);
+    }
+
+}

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/exceptions/ProblemDetails.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/exceptions/ProblemDetails.java
@@ -2,6 +2,7 @@ package co.com.pragma.crediya.api.exceptions;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.Setter;
@@ -16,6 +17,7 @@ import java.util.List;
         name = "ProblemDetails",
         description = "Standardized error response body following RFC 7807 style"
 )
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ProblemDetails {
 
     @Schema(description = "Short, human-readable title of the error", example = "Invalid Request")
@@ -63,6 +65,10 @@ public class ProblemDetails {
 
     public static ProblemDetails badRequest(String title, List<FieldValidationError> errors) {
         return new ProblemDetails(title, null, HttpStatus.BAD_REQUEST, errors);
+    }
+
+    public static ProblemDetails badRequest(String title, String message) {
+        return new ProblemDetails(title, message, HttpStatus.BAD_REQUEST, null);
     }
 
     public static ProblemDetails conflict(String title, List<FieldValidationError> errors) {

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/exceptions/handler/GlobalExceptionHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/exceptions/handler/GlobalExceptionHandler.java
@@ -1,10 +1,7 @@
 package co.com.pragma.crediya.api.exceptions.handler;
 
 import co.com.pragma.crediya.api.constants.HttpErrorTitles;
-import co.com.pragma.crediya.api.exceptions.EmptyRequestBodyException;
-import co.com.pragma.crediya.api.exceptions.FieldValidationError;
-import co.com.pragma.crediya.api.exceptions.JwtAuthenticationException;
-import co.com.pragma.crediya.api.exceptions.ProblemDetails;
+import co.com.pragma.crediya.api.exceptions.*;
 import co.com.pragma.crediya.model.loan.constants.ApplicationFieldNames;
 import co.com.pragma.crediya.model.loan.exceptions.ApplicationValueOutOfBoundsException;
 import co.com.pragma.crediya.model.loan.exceptions.TypeNotFoundException;
@@ -64,7 +61,11 @@ public class GlobalExceptionHandler implements ErrorWebExceptionHandler {
         }
 
         if (ex instanceof EmptyRequestBodyException) {
-            return ProblemDetails.badRequest(ex.getMessage(), null);
+            return ProblemDetails.badRequest(HttpErrorTitles.BAD_REQUEST, ex.getMessage());
+        }
+
+        if (ex instanceof InvalidQueryParamException) {
+            return ProblemDetails.badRequest(HttpErrorTitles.BAD_REQUEST, ex.getMessage());
         }
 
         if (ex instanceof ApplicationValueOutOfBoundsException) {

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/mapper/LoanApplicationRestFilterMapper.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/mapper/LoanApplicationRestFilterMapper.java
@@ -1,0 +1,80 @@
+package co.com.pragma.crediya.api.mapper;
+
+import co.com.pragma.crediya.api.constants.ApiConstants;
+import co.com.pragma.crediya.api.constants.FilterParams;
+import co.com.pragma.crediya.api.exceptions.InvalidQueryParamException;
+import co.com.pragma.crediya.model.loan.report.LoanApplicationFilter;
+import org.springframework.web.reactive.function.server.ServerRequest;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.IntPredicate;
+import java.util.function.Predicate;
+
+public class LoanApplicationRestFilterMapper {
+
+    private LoanApplicationRestFilterMapper() {
+    }
+
+    public static LoanApplicationFilter fromServerRequest(ServerRequest request) {
+        Set<String> statuses = getQueryParam(request, FilterParams.STATUSES)
+                .map(s -> Set.of(s.split(ApiConstants.PARAM_DELIMITER)))
+                .orElse(Set.of());
+
+        BigDecimal minAmount = getBigDecimalParam(request, FilterParams.MIN_AMOUNT, a -> a.compareTo(BigDecimal.ZERO) >= 0);
+        BigDecimal maxAmount = getBigDecimalParam(request, FilterParams.MAX_AMOUNT, a -> a.compareTo(BigDecimal.ZERO) >= 0);
+
+        Integer minTerm = getIntParam(request, FilterParams.MIN_TERM, null, t -> t > 0);
+        Integer maxTerm = getIntParam(request, FilterParams.MAX_TERM, null, t -> t > 0);
+
+        String email = getQueryParam(request, FilterParams.EMAIL).orElse(null);
+        String loanType = getQueryParam(request, FilterParams.LOAN_TYPE).orElse(null);
+
+        int limit = getIntParam(request, FilterParams.LIMIT, ApiConstants.DEFAULT_LIMIT, l -> l > 0);
+        int page = getIntParam(request, FilterParams.PAGE, ApiConstants.DEFAULT_PAGE, o -> o > 0);
+
+        return new LoanApplicationFilter(statuses, minAmount, maxAmount, minTerm, maxTerm, email, loanType, limit, page);
+    }
+
+    private static Optional<String> getQueryParam(ServerRequest request, String key) {
+        return request.queryParam(key).filter(s -> !s.isBlank());
+    }
+
+    private static Integer getIntParam(ServerRequest request, String paramName, Integer defaultValue, IntPredicate validator) {
+        return getQueryParam(request, paramName)
+                .map(s -> {
+                    try {
+                        int value = Integer.parseInt(s);
+                        if (!validator.test(value)) {
+                            throw new InvalidQueryParamException("Query param out of valid range: " + paramName);
+                        }
+                        return value;
+                    } catch (NumberFormatException e) {
+                        throw new InvalidQueryParamException("Invalid integer for query param: " + paramName);
+                    }
+                })
+                .orElse(defaultValue);
+    }
+
+    private static BigDecimal getBigDecimalParam(ServerRequest request, String paramName, Predicate<BigDecimal> validator) {
+        return getQueryParam(request, paramName)
+                .map(s -> {
+                    try {
+                        return new BigDecimal(s);
+                    } catch (NumberFormatException e) {
+                        throw new InvalidQueryParamException("Invalid decimal for query param: " + paramName);
+                    }
+                })
+                .filter(value -> {
+                    if (!validator.test(value)) {
+                        throw new InvalidQueryParamException("Query param out of valid range: " + paramName);
+                    }
+                    return true;
+                })
+                .orElse(null);
+    }
+
+
+}
+

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/RouterRestTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/RouterRestTest.java
@@ -16,6 +16,7 @@ import co.com.pragma.crediya.model.jwt.Jwt;
 import co.com.pragma.crediya.model.jwt.gateways.JwtProviderPort;
 import co.com.pragma.crediya.model.loan.Application;
 import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
+import co.com.pragma.crediya.usecase.loan.report.ApplicationReportUseCase;
 import co.com.pragma.crediya.usecase.loan.ApplicationUseCase;
 import jakarta.validation.Validator;
 import org.assertj.core.api.Assertions;
@@ -76,6 +77,9 @@ class RouterRestTest {
 
     @MockitoBean
     private LoggerPort logger;
+
+    @MockitoBean
+    private ApplicationReportUseCase applicationReportUseCase;
 
     @MockitoBean
     private ApplicationUseCase applicationUseCase;

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/config/ConfigTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/config/ConfigTest.java
@@ -11,6 +11,7 @@ import co.com.pragma.crediya.api.validator.ReactiveValidator;
 import co.com.pragma.crediya.model.common.constants.DomainConstants;
 import co.com.pragma.crediya.model.jwt.Jwt;
 import co.com.pragma.crediya.model.jwt.gateways.JwtProviderPort;
+import co.com.pragma.crediya.usecase.loan.report.ApplicationReportUseCase;
 import co.com.pragma.crediya.usecase.loan.ApplicationUseCase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,6 +63,9 @@ class ConfigTest {
 
     @MockitoBean
     private LoanApplicationRestMapper mapper;
+
+    @MockitoBean
+    private ApplicationReportUseCase applicationReportUseCase;
 
     @MockitoBean
     private ApplicationUseCase userUseCase;


### PR DESCRIPTION
- Implement GET /api/v1/loan-applications in the Loan Applications microservice (WebFlux)
- Follow hexagonal architecture separating domain and infrastructure
- Restrict access to users with the "Advisor" role
- Add trace logs for monitoring
- Implement centralized exception handling to avoid exposing unexpected messages
- Return a paginated and filterable report of loan applications pending review
- Include the following fields in the report: email, baseSalary, totalMonthlyDebt, type, amount,term, interestRate, status