### PR TITLE
 feat(loans): add automated loan validation with debt capacity calculation

### DIFF
--- a/applications/app-service/build.gradle
+++ b/applications/app-service/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'org.springframework.boot'
 
 dependencies {
+	implementation project(':mustache-template')
+	implementation project(':sqs-listener')
 	implementation project(':sqs-sender')
 	implementation project(':metrics')
 	implementation project(':jwt')

--- a/applications/app-service/src/main/java/co/com/pragma/crediya/config/UseCasesConfig.java
+++ b/applications/app-service/src/main/java/co/com/pragma/crediya/config/UseCasesConfig.java
@@ -7,7 +7,9 @@ import org.springframework.context.annotation.FilterType;
 @Configuration
 @ComponentScan(basePackages = "co.com.pragma.crediya.usecase",
         includeFilters = {
-                @ComponentScan.Filter(type = FilterType.REGEX, pattern = "^.+UseCase$")
+                @ComponentScan.Filter(type = FilterType.REGEX, pattern = "^.+UseCase$"),
+                @ComponentScan.Filter(type = FilterType.REGEX, pattern = "^.+Orchestrator$"),
+                @ComponentScan.Filter(type = FilterType.REGEX, pattern = "^.+Validator$")
         },
         useDefaultFilters = false)
 public class UseCasesConfig {

--- a/applications/app-service/src/main/resources/application-dev.yaml
+++ b/applications/app-service/src/main/resources/application-dev.yaml
@@ -22,6 +22,18 @@ adapters:
   sqs:
     region: "${AWS_SQS_REGION}"
     queueUrl: "${AWS_SQS_QUEUE_URL}"
+    loanNotificationQueueName: "${AWS_SQS_LOAN_NOTIFICATION_QUEUE_NAME}"
+    loanAutoValidationQueueName: "${AWS_SQS_LOAN_AUTO_VALIDATION_QUEUE_NAME}"
+
+entrypoint:
+  sqs:
+    region: "${AWS_SQS_REGION}"
+    queueUrl: "${AWS_SQS_QUEUE_URL}"
+    loanValidationResponseQueueName: "${AWS_SQS_LOAN_VALIDATION_RESPONSE_QUEUE_NAME}"
+    waitTimeSeconds: 20
+    maxNumberOfMessages: 10
+    visibilityTimeoutSeconds: 10
+    numberOfThreads: 1
 
 application:
   security:

--- a/applications/app-service/src/main/resources/application-local.yaml
+++ b/applications/app-service/src/main/resources/application-local.yaml
@@ -22,7 +22,18 @@ adapters:
   sqs:
     region: "${AWS_SQS_REGION}"
     queueUrl: "${AWS_SQS_QUEUE_URL}"
+    loanNotificationQueueName: "${AWS_SQS_LOAN_NOTIFICATION_QUEUE_NAME}"
+    loanAutoValidationQueueName: "${AWS_SQS_LOAN_AUTO_VALIDATION_QUEUE_NAME}"
 
+entrypoint:
+  sqs:
+    region: "${AWS_SQS_REGION}"
+    queueUrl: "${AWS_SQS_QUEUE_URL}"
+    loanValidationResponseQueueName: "${AWS_SQS_LOAN_VALIDATION_RESPONSE_QUEUE_NAME}"
+    waitTimeSeconds: 20
+    maxNumberOfMessages: 10
+    visibilityTimeoutSeconds: 10
+    numberOfThreads: 1
 
 application:
   security:

--- a/applications/app-service/src/main/resources/application-prod.yaml
+++ b/applications/app-service/src/main/resources/application-prod.yaml
@@ -22,6 +22,18 @@ adapters:
   sqs:
     region: "${AWS_SQS_REGION}"
     queueUrl: "${AWS_SQS_QUEUE_URL}"
+    loanNotificationQueueName: "${AWS_SQS_LOAN_NOTIFICATION_QUEUE_NAME}"
+    loanAutoValidationQueueName: "${AWS_SQS_LOAN_AUTO_VALIDATION_QUEUE_NAME}"
+
+entrypoint:
+  sqs:
+    region: "${AWS_SQS_REGION}"
+    queueUrl: "${AWS_SQS_QUEUE_URL}"
+    loanValidationResponseQueueName: "${AWS_SQS_LOAN_VALIDATION_RESPONSE_QUEUE_NAME}"
+    waitTimeSeconds: 20
+    maxNumberOfMessages: 10
+    visibilityTimeoutSeconds: 10
+    numberOfThreads: 1
 
 application:
   security:

--- a/applications/app-service/src/test/java/co/com/pragma/crediya/config/UseCasesConfigTest.java
+++ b/applications/app-service/src/test/java/co/com/pragma/crediya/config/UseCasesConfigTest.java
@@ -2,10 +2,12 @@ package co.com.pragma.crediya.config;
 
 import co.com.pragma.crediya.model.jwt.gateways.JwtProviderPort;
 import co.com.pragma.crediya.model.loan.gateways.ApplicationRepository;
+import co.com.pragma.crediya.model.loan.gateways.LoanValidationPort;
 import co.com.pragma.crediya.model.notification.gateways.NotificationPort;
 import co.com.pragma.crediya.model.loan.gateways.StatusRepository;
 import co.com.pragma.crediya.model.loan.gateways.TypeRepository;
 import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
+import co.com.pragma.crediya.model.notification.gateways.NotificationRendererPort;
 import co.com.pragma.crediya.model.transaction.gateways.TransactionalPort;
 import co.com.pragma.crediya.model.user.gateways.UserPort;
 import org.junit.jupiter.api.Test;
@@ -80,5 +82,16 @@ class UseCasesConfigTest {
             return Mockito.mock(NotificationPort.class);
         }
 
+        @Bean
+        public NotificationRendererPort notificationRendererPort() {
+            return Mockito.mock(NotificationRendererPort.class);
+        }
+
+        @Bean
+        public LoanValidationPort loanValidationPort() {
+            return Mockito.mock(LoanValidationPort.class);
+        }
+
     }
+
 }

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/StatusChange.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/StatusChange.java
@@ -1,0 +1,9 @@
+package co.com.pragma.crediya.model;
+
+import java.math.BigDecimal;
+
+public record StatusChange(
+        String status,
+        String loanType,
+        BigDecimal amount) {
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/common/validation/ValidationOutcome.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/common/validation/ValidationOutcome.java
@@ -1,0 +1,13 @@
+package co.com.pragma.crediya.model.common.validation;
+
+public record ValidationOutcome(boolean isValid, String field, String errorMessage) {
+
+    public static ValidationOutcome success(String field) {
+        return new ValidationOutcome(true, field, null);
+    }
+
+    public static ValidationOutcome error(String field, String message) {
+        return new ValidationOutcome(false, field, message);
+    }
+
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/jwt/Jwt.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/jwt/Jwt.java
@@ -1,6 +1,7 @@
 package co.com.pragma.crediya.model.jwt;
 
+import java.math.BigDecimal;
 import java.util.List;
 
-public record Jwt(String subject, List<String> roles, String identificationNumber) {
+public record Jwt(String subject, List<String> roles, String identificationNumber, BigDecimal baseSalary) {
 }

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/ActiveApplication.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/ActiveApplication.java
@@ -1,0 +1,9 @@
+package co.com.pragma.crediya.model.loan;
+
+import java.math.BigDecimal;
+
+public record ActiveApplication(
+        BigDecimal amount,
+        Integer term,
+        BigDecimal interestRate) {
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/ApplicationRiskEvaluation.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/ApplicationRiskEvaluation.java
@@ -1,0 +1,15 @@
+package co.com.pragma.crediya.model.loan;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+public record ApplicationRiskEvaluation(
+        UUID id,
+        String type,
+        BigDecimal amount,
+        int term,
+        BigDecimal interestRate,
+        BigDecimal baseSalary,
+        List<ActiveApplication> activeApplications) {
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/LoanValidation.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/LoanValidation.java
@@ -1,0 +1,10 @@
+package co.com.pragma.crediya.model.loan;
+
+import java.util.List;
+import java.util.UUID;
+
+public record LoanValidation(
+        UUID id,
+        String status,
+        List<PaymentDetail> paymentDetail) {
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/PaymentDetail.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/PaymentDetail.java
@@ -1,0 +1,11 @@
+package co.com.pragma.crediya.model.loan;
+
+import java.math.BigDecimal;
+
+public record PaymentDetail(
+        int month,
+        BigDecimal installment,
+        BigDecimal principal,
+        BigDecimal interest,
+        BigDecimal balance) {
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/Type.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/Type.java
@@ -8,6 +8,8 @@ public record Type(
         String name,
         BigDecimal minimumAmount,
         BigDecimal maximumAmount,
+        int minimumTerm,
+        int maximumTerm,
         BigDecimal interestRate,
         Boolean automaticValidation) {
 }

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/constants/ApplicationConstants.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/constants/ApplicationConstants.java
@@ -23,6 +23,4 @@ public final class ApplicationConstants {
 
     public static final String LOAN_STATUS_UPDATE_SUBJECT = "Loan Application Status Update";
 
-    public static final String LOAN_STATUS_UPDATE_BODY_TEMPLATE = "Your loan application has been %s.";
-
 }

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/constants/ApplicationErrorMessages.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/constants/ApplicationErrorMessages.java
@@ -11,4 +11,6 @@ public final class ApplicationErrorMessages {
 
     public static final String STATUS_NOT_FOUND = "We couldn’t find the specified loan status.";
 
+    public static final String APPLICATION_BUSINESS_VALIDATION_FAILED = "Application business validation failed";
+
 }

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/constants/ApplicationFieldNames.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/constants/ApplicationFieldNames.java
@@ -9,6 +9,8 @@ public final class ApplicationFieldNames {
 
     public static final String AMOUNT = "amount";
 
+    public static final String TERM = "term";
+
     public static final String TYPE = "type";
 
     public static final String STATUS = "status";

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/exceptions/ApplicationBusinessValidationException.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/exceptions/ApplicationBusinessValidationException.java
@@ -1,0 +1,22 @@
+package co.com.pragma.crediya.model.loan.exceptions;
+
+import co.com.pragma.crediya.model.common.validation.ValidationOutcome;
+import co.com.pragma.crediya.model.loan.constants.ApplicationErrorMessages;
+
+import java.util.List;
+
+public class ApplicationBusinessValidationException extends RuntimeException {
+
+    private final transient List<ValidationOutcome> errors;
+
+    public ApplicationBusinessValidationException(List<ValidationOutcome> errors) {
+        super(ApplicationErrorMessages.APPLICATION_BUSINESS_VALIDATION_FAILED);
+
+        this.errors = errors;
+    }
+
+    public List<ValidationOutcome> getErrors() {
+        return errors;
+    }
+
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/exceptions/ApplicationTermOutOfBoundsException.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/exceptions/ApplicationTermOutOfBoundsException.java
@@ -1,0 +1,22 @@
+package co.com.pragma.crediya.model.loan.exceptions;
+
+import co.com.pragma.crediya.model.loan.constants.ApplicationConstants;
+import co.com.pragma.crediya.model.loan.constants.ApplicationFieldNames;
+
+public class ApplicationTermOutOfBoundsException extends RuntimeException {
+
+    public ApplicationTermOutOfBoundsException(int minValue, int maxValue) {
+        super(buildMessage(minValue, maxValue));
+    }
+
+    private static String buildMessage(int minValue, int maxValue) {
+        return String.join(" ",
+                ApplicationFieldNames.TERM,
+                ApplicationConstants.MOST_BE_BETWEEN,
+                String.valueOf(minValue),
+                ApplicationConstants.AND_CONNECTOR,
+                String.valueOf(maxValue)
+        );
+    }
+
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/gateways/ApplicationRepository.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/gateways/ApplicationRepository.java
@@ -1,5 +1,6 @@
 package co.com.pragma.crediya.model.loan.gateways;
 
+import co.com.pragma.crediya.model.loan.ActiveApplication;
 import co.com.pragma.crediya.model.loan.Application;
 import co.com.pragma.crediya.model.loan.report.ApplicationReport;
 import co.com.pragma.crediya.model.loan.report.LoanApplicationFilter;
@@ -21,5 +22,7 @@ public interface ApplicationRepository {
     Flux<ApplicationReport> findApplicationsReport(LoanApplicationFilter filter);
 
     Mono<Long> countLoanApplications(LoanApplicationFilter filter);
+
+    Flux<ActiveApplication> findActiveLoansByIdentificationNumber(String identificationNumber);
 
 }

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/gateways/LoanValidationPort.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/gateways/LoanValidationPort.java
@@ -1,0 +1,10 @@
+package co.com.pragma.crediya.model.loan.gateways;
+
+import co.com.pragma.crediya.model.loan.ApplicationRiskEvaluation;
+import reactor.core.publisher.Mono;
+
+public interface LoanValidationPort {
+
+    Mono<Void> validateLoanAutomatically(ApplicationRiskEvaluation applicationRiskEvaluation);
+
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/notification/LoanApproval.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/notification/LoanApproval.java
@@ -1,0 +1,15 @@
+package co.com.pragma.crediya.model.notification;
+
+import co.com.pragma.crediya.model.loan.PaymentDetail;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record LoanApproval(
+        String loanType,
+        BigDecimal amount,
+        int term,
+        BigDecimal interestRate,
+        BigDecimal monthlyPayment,
+        List<PaymentDetail> paymentDetail) {
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/notification/NotificationMessage.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/notification/NotificationMessage.java
@@ -1,39 +1,7 @@
 package co.com.pragma.crediya.model.notification;
 
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 public record NotificationMessage(
         String to,
         String subject,
         String body) {
-
-    private static final Map<String, String> ESCAPES = Map.of(
-            "\"", "\\\"",
-            "\n", "\\n",
-            "\r", "\\r"
-    );
-
-    private static final Pattern ESCAPE_PATTERN = Pattern.compile("[\"\\n\\r]");
-
-    public String toJson() {
-        return String.format("""
-                {"to":"%s","subject":"%s","body":"%s"}
-                """, to, subject, escapeJson(body));
-    }
-
-    private String escapeJson(String value) {
-        Matcher m = ESCAPE_PATTERN.matcher(value);
-        StringBuilder sb = new StringBuilder();
-
-        while (m.find()) {
-            m.appendReplacement(sb, ESCAPES.get(m.group()));
-        }
-
-        m.appendTail(sb);
-
-        return sb.toString();
-    }
-
 }

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/notification/gateways/NotificationPort.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/notification/gateways/NotificationPort.java
@@ -1,9 +1,10 @@
 package co.com.pragma.crediya.model.notification.gateways;
 
 import co.com.pragma.crediya.model.notification.NotificationMessage;
+import reactor.core.publisher.Mono;
 
 public interface NotificationPort {
 
-    void sendNotification(NotificationMessage message);
+    Mono<Void> sendNotification(NotificationMessage message);
 
 }

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/notification/gateways/NotificationRendererPort.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/notification/gateways/NotificationRendererPort.java
@@ -1,0 +1,14 @@
+package co.com.pragma.crediya.model.notification.gateways;
+
+import co.com.pragma.crediya.model.StatusChange;
+import co.com.pragma.crediya.model.notification.LoanApproval;
+import reactor.core.publisher.Mono;
+
+public interface NotificationRendererPort {
+
+    Mono<String> processLoanApprovalTemplate(LoanApproval approval);
+
+    Mono<String> processStatusChangeTemplate(StatusChange statusChange);
+
+}
+

--- a/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/ApplicationUseCase.java
+++ b/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/ApplicationUseCase.java
@@ -1,20 +1,23 @@
 package co.com.pragma.crediya.usecase.loan;
 
+import co.com.pragma.crediya.model.StatusChange;
 import co.com.pragma.crediya.model.common.constants.DomainConstants;
 import co.com.pragma.crediya.model.jwt.Jwt;
-import co.com.pragma.crediya.model.loan.Application;
-import co.com.pragma.crediya.model.loan.Status;
-import co.com.pragma.crediya.model.loan.Type;
+import co.com.pragma.crediya.model.loan.*;
 import co.com.pragma.crediya.model.loan.constants.ApplicationConstants;
 import co.com.pragma.crediya.model.loan.constants.ApplicationErrorMessages;
 import co.com.pragma.crediya.model.loan.exceptions.*;
 import co.com.pragma.crediya.model.loan.gateways.ApplicationRepository;
-import co.com.pragma.crediya.model.notification.gateways.NotificationPort;
+import co.com.pragma.crediya.model.loan.gateways.LoanValidationPort;
 import co.com.pragma.crediya.model.loan.gateways.StatusRepository;
 import co.com.pragma.crediya.model.loan.gateways.TypeRepository;
-import co.com.pragma.crediya.model.notification.NotificationMessage;
 import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
+import co.com.pragma.crediya.model.notification.LoanApproval;
+import co.com.pragma.crediya.model.notification.NotificationMessage;
+import co.com.pragma.crediya.model.notification.gateways.NotificationPort;
+import co.com.pragma.crediya.model.notification.gateways.NotificationRendererPort;
 import co.com.pragma.crediya.model.transaction.gateways.TransactionalPort;
+import co.com.pragma.crediya.usecase.loan.utils.ApplicationCalculatorUtils;
 import reactor.core.publisher.Mono;
 
 import java.math.BigDecimal;
@@ -24,6 +27,8 @@ public record ApplicationUseCase(TypeRepository typeRepository,
                                  StatusRepository statusRepository,
                                  ApplicationRepository applicationRepository,
                                  NotificationPort notificationPort,
+                                 NotificationRendererPort notificationRendererPort,
+                                 LoanValidationPort loanValidationPort,
                                  LoggerPort logger,
                                  TransactionalPort transactionalPort) {
 
@@ -44,7 +49,7 @@ public record ApplicationUseCase(TypeRepository typeRepository,
                 status
         );
 
-        return processAndSaveApplication(applicationWithPendingStatusAndUserEmail);
+        return processAndSaveApplication(applicationWithPendingStatusAndUserEmail, token.baseSalary());
     }
 
     public Mono<Application> processAndApproveOrReject(UUID id, String newStatus) {
@@ -68,23 +73,42 @@ public record ApplicationUseCase(TypeRepository typeRepository,
                     return findStatusByName(newStatus)
                             .map(status -> buildApplicationWithTypeAndStatus(application, application.type(), status));
                 })
-                .flatMap(application ->
-                        applicationRepository.save(application)
-                                .map(storedApplication -> buildApplicationWithTypeAndStatus(storedApplication, application.type(), application.status()))
-                                .doOnSuccess(storedApplication -> {
-                                    String body = String.format(ApplicationConstants.LOAN_STATUS_UPDATE_BODY_TEMPLATE, storedApplication.status().name().toLowerCase());
-
-                                    NotificationMessage notification = new NotificationMessage(storedApplication.email(), ApplicationConstants.LOAN_STATUS_UPDATE_SUBJECT, body);
-
-                                    notificationPort.sendNotification(notification);
-                                })
-                )
+                .flatMap(this::saveApplication)
                 .as(transactionalPort::transactional)
+                .flatMap(storedApplication ->
+                        sendStatusNotification(storedApplication, storedApplication.status().name())
+                                .thenReturn(storedApplication)
+                )
                 .doOnSuccess(storedApplication -> logger.info("Loan application with ID {} updated successfully.", storedApplication.id()))
                 .doOnError(e -> logger.error("Failed to update loan application with ID {}. Reason: {}", id, e.getMessage(), e));
     }
 
-    private Mono<Application> processAndSaveApplication(Application application) {
+    public Mono<Void> processApplicationStatusUpdate(LoanValidation result) {
+        logger.info("Starting application status update for application ID: {} with new status: {}", result.id(), result.status());
+
+        return findStatusByName(result.status())
+                .flatMap(status ->
+                        findApplicationById(result.id())
+                                .flatMap(application ->
+                                        findTypeById(application.type().id())
+                                                .map(type -> buildApplicationWithTypeAndStatus(application, type, status))
+                                )
+                )
+                .flatMap(this::saveApplication)
+                .as(transactionalPort::transactional)
+                .flatMap(storedApplication -> {
+                    logger.info("Application with ID {} updated to status {}", storedApplication.id(), result.status());
+
+                    if (result.status().equalsIgnoreCase(DomainConstants.APPROVED_STATUS)) {
+                        return sendApprovalNotification(storedApplication, result);
+                    }
+
+                    return sendStatusNotification(storedApplication, result.status());
+                })
+                .doOnError(e -> logger.error("Failed to update application status for ID {}. Reason: {}", result.id(), e.getMessage(), e));
+    }
+
+    private Mono<Application> processAndSaveApplication(Application application, BigDecimal baseSalary) {
         Mono<Type> loanTypeMono = findTypeByName(application.type().name());
 
         Mono<Status> loanStatusMono = findStatusByName(application.status().name());
@@ -97,12 +121,69 @@ public record ApplicationUseCase(TypeRepository typeRepository,
                     Application applicationWithTypeAndStatus = buildApplicationWithTypeAndStatus(application, loanType, loanStatus);
 
                     return validateLoanAmount(applicationWithTypeAndStatus)
-                            .flatMap(applicationRepository::save)
-                            .map(loan -> buildApplicationWithTypeAndStatus(loan, loanType, loanStatus));
+                            .flatMap(this::saveApplication);
                 })
                 .as(transactionalPort::transactional)
+                .flatMap(storedApplication ->
+                        afterApplicationSaved(storedApplication, baseSalary)
+                                .thenReturn(storedApplication)
+                )
                 .doOnSuccess(storedApplication -> logger.info("Loan application saved successfully with id: {}", storedApplication.id()))
                 .doOnError(e -> logger.error("Failed to save loan application for user with identification number: " + application.identificationNumber(), e));
+    }
+
+    private Mono<Void> sendStatusNotification(Application application, String status) {
+        StatusChange statusChange = new StatusChange(status.toLowerCase(), application.type().name(), application.amount());
+
+        return notificationRendererPort.processStatusChangeTemplate(statusChange)
+                .flatMap(html -> sendEmailNotification(application.email(), html));
+    }
+
+    private Mono<Void> sendApprovalNotification(Application application, LoanValidation result) {
+        LoanApproval approval = new LoanApproval(
+                application.type().name(),
+                application.amount(),
+                application.term(),
+                ApplicationCalculatorUtils.annualToMonthlyRate(application.type().interestRate()),
+                result.paymentDetail().getFirst().installment(),
+                result.paymentDetail()
+        );
+
+        return notificationRendererPort.processLoanApprovalTemplate(approval)
+                .flatMap(html -> sendEmailNotification(application.email(), html));
+    }
+
+    private Mono<Void> sendEmailNotification(String email, String body) {
+        NotificationMessage notification = new NotificationMessage(
+                email,
+                ApplicationConstants.LOAN_STATUS_UPDATE_SUBJECT,
+                body
+        );
+        return notificationPort.sendNotification(notification);
+    }
+
+    private Mono<Application> saveApplication(Application application) {
+        return applicationRepository.save(application)
+                .map(storedApplication -> buildApplicationWithTypeAndStatus(storedApplication, application.type(), application.status()));
+    }
+
+    private Mono<Void> afterApplicationSaved(Application application, BigDecimal baseSalary) {
+        if (Boolean.FALSE.equals(application.type().automaticValidation())) return Mono.empty();
+
+        return applicationRepository.findActiveLoansByIdentificationNumber(application.identificationNumber())
+                .collectList()
+                .map(activeApplications ->
+                        new ApplicationRiskEvaluation(
+                                application.id(),
+                                application.type().name(),
+                                application.amount(),
+                                application.term(),
+                                ApplicationCalculatorUtils.annualToMonthlyRate(application.type().interestRate()),
+                                baseSalary,
+                                activeApplications
+                        )
+                )
+                .flatMap(loanValidationPort::validateLoanAutomatically);
     }
 
     private Mono<Application> findApplicationById(UUID id) {

--- a/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/ApplicationUseCase.java
+++ b/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/ApplicationUseCase.java
@@ -2,6 +2,7 @@ package co.com.pragma.crediya.usecase.loan;
 
 import co.com.pragma.crediya.model.StatusChange;
 import co.com.pragma.crediya.model.common.constants.DomainConstants;
+import co.com.pragma.crediya.model.common.validation.ValidationOutcome;
 import co.com.pragma.crediya.model.jwt.Jwt;
 import co.com.pragma.crediya.model.loan.*;
 import co.com.pragma.crediya.model.loan.constants.ApplicationConstants;
@@ -18,14 +19,17 @@ import co.com.pragma.crediya.model.notification.gateways.NotificationPort;
 import co.com.pragma.crediya.model.notification.gateways.NotificationRendererPort;
 import co.com.pragma.crediya.model.transaction.gateways.TransactionalPort;
 import co.com.pragma.crediya.usecase.loan.utils.ApplicationCalculatorUtils;
+import co.com.pragma.crediya.usecase.loan.validation.ValidationLoanApplicationOrchestrator;
 import reactor.core.publisher.Mono;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.UUID;
 
 public record ApplicationUseCase(TypeRepository typeRepository,
                                  StatusRepository statusRepository,
                                  ApplicationRepository applicationRepository,
+                                 ValidationLoanApplicationOrchestrator validationLoanApplicationOrchestrator,
                                  NotificationPort notificationPort,
                                  NotificationRendererPort notificationRendererPort,
                                  LoanValidationPort loanValidationPort,
@@ -120,7 +124,7 @@ public record ApplicationUseCase(TypeRepository typeRepository,
 
                     Application applicationWithTypeAndStatus = buildApplicationWithTypeAndStatus(application, loanType, loanStatus);
 
-                    return validateLoanAmount(applicationWithTypeAndStatus)
+                    return validateApplicationBusinessRules(applicationWithTypeAndStatus)
                             .flatMap(this::saveApplication);
                 })
                 .as(transactionalPort::transactional)
@@ -228,16 +232,19 @@ public record ApplicationUseCase(TypeRepository typeRepository,
         );
     }
 
-    private Mono<Application> validateLoanAmount(Application application) {
-        BigDecimal amount = application.amount();
-        BigDecimal minValue = application.type().minimumAmount();
-        BigDecimal maxValue = application.type().maximumAmount();
+    private Mono<Application> validateApplicationBusinessRules(Application application) {
+        return validationLoanApplicationOrchestrator.validateApplicationBusinessRules(application)
+                .flatMap(outcomes -> {
+                    List<ValidationOutcome> errors = outcomes.stream()
+                            .filter(outcome -> !outcome.isValid())
+                            .toList();
 
-        if (amount.compareTo(minValue) < 0 || amount.compareTo(maxValue) > 0) {
-            return Mono.error(new ApplicationValueOutOfBoundsException(minValue, maxValue));
-        }
+                    if (!errors.isEmpty()) {
+                        return Mono.error(new ApplicationBusinessValidationException(errors));
+                    }
 
-        return Mono.just(application);
+                    return Mono.just(application);
+                });
     }
 
     private boolean isValidStatusTransition(String newStatus) {

--- a/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/report/ApplicationReportUseCase.java
+++ b/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/report/ApplicationReportUseCase.java
@@ -12,7 +12,6 @@ import co.com.pragma.crediya.usecase.loan.utils.ApplicationCalculatorUtils;
 import reactor.core.publisher.Mono;
 
 import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -21,12 +20,6 @@ import java.util.stream.Collectors;
 public record ApplicationReportUseCase(ApplicationRepository applicationRepository,
                                        UserPort userPort,
                                        LoggerPort logger) {
-
-    private static final BigDecimal MONTHS_IN_YEAR_PERCENT = BigDecimal.valueOf(1200);
-
-    private static final int INTEREST_RATE_SCALE = 10;
-
-    private static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
 
     public Mono<LoanApplicationsReport> getLoanApplicationsReport(LoanApplicationFilter filter) {
         logger.info("Get loan applications report with filters: {}", filter);
@@ -73,8 +66,8 @@ public record ApplicationReportUseCase(ApplicationRepository applicationReposito
                     User user = userMap.get(report.email());
                     BigDecimal baseSalary = user != null ? user.baseSalary() : BigDecimal.ZERO;
 
-                    BigDecimal interestRateDecimal = report.interestRate().divide(MONTHS_IN_YEAR_PERCENT, INTEREST_RATE_SCALE, ROUNDING_MODE);
-                    BigDecimal monthlyPayment = ApplicationCalculatorUtils.calculateMonthlyPayment(report.amount(), interestRateDecimal, report.term());
+                    BigDecimal monthlyRate = ApplicationCalculatorUtils.annualToMonthlyRate(report.interestRate());
+                    BigDecimal monthlyPayment = ApplicationCalculatorUtils.calculateMonthlyPayment(report.amount(), monthlyRate, report.term());
 
                     return new CustomerApplication(
                             report.id(),

--- a/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/utils/ApplicationCalculatorUtils.java
+++ b/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/utils/ApplicationCalculatorUtils.java
@@ -11,6 +11,8 @@ public class ApplicationCalculatorUtils {
 
     private static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
 
+    private static final BigDecimal MONTHS_IN_YEAR_PERCENT = BigDecimal.valueOf(1200);
+
     private ApplicationCalculatorUtils() {
     }
 
@@ -28,6 +30,10 @@ public class ApplicationCalculatorUtils {
         );
 
         return numerator.divide(denominator, RESULT_SCALE, ROUNDING_MODE);
+    }
+
+    public static BigDecimal annualToMonthlyRate(BigDecimal annualRate) {
+        return annualRate.divide(MONTHS_IN_YEAR_PERCENT, CALCULATION_SCALE, ROUNDING_MODE);
     }
 
 }

--- a/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/validation/LoanAmountValidator.java
+++ b/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/validation/LoanAmountValidator.java
@@ -1,0 +1,30 @@
+package co.com.pragma.crediya.usecase.loan.validation;
+
+import co.com.pragma.crediya.model.common.validation.ValidationOutcome;
+import co.com.pragma.crediya.model.loan.Application;
+import co.com.pragma.crediya.model.loan.constants.ApplicationFieldNames;
+import co.com.pragma.crediya.model.loan.exceptions.ApplicationValueOutOfBoundsException;
+import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+
+public record LoanAmountValidator(LoggerPort logger) {
+
+    public Mono<ValidationOutcome> validate(Application application) {
+        BigDecimal amount = application.amount();
+        BigDecimal minValue = application.type().minimumAmount();
+        BigDecimal maxValue = application.type().maximumAmount();
+
+        if (amount.compareTo(minValue) < 0 || amount.compareTo(maxValue) > 0) {
+            ApplicationValueOutOfBoundsException ex = new ApplicationValueOutOfBoundsException(minValue, maxValue);
+            logger.error("Loan amount validation failed. Amount: {}, Min: {}, Max: {}", amount, minValue, maxValue, ex);
+
+            return Mono.just(ValidationOutcome.error(ApplicationFieldNames.AMOUNT, ex.getMessage()));
+        }
+
+        logger.info("Loan amount validation passed. Amount: {}, Min: {}, Max: {}", amount, minValue, maxValue);
+        return Mono.just(ValidationOutcome.success(ApplicationFieldNames.AMOUNT));
+    }
+
+}

--- a/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/validation/LoanTermValidator.java
+++ b/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/validation/LoanTermValidator.java
@@ -1,0 +1,28 @@
+package co.com.pragma.crediya.usecase.loan.validation;
+
+import co.com.pragma.crediya.model.common.validation.ValidationOutcome;
+import co.com.pragma.crediya.model.loan.Application;
+import co.com.pragma.crediya.model.loan.constants.ApplicationFieldNames;
+import co.com.pragma.crediya.model.loan.exceptions.ApplicationTermOutOfBoundsException;
+import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
+import reactor.core.publisher.Mono;
+
+public record LoanTermValidator(LoggerPort logger) {
+
+    public Mono<ValidationOutcome> validate(Application application) {
+        int term = application.term();
+        int minValue = application.type().minimumTerm();
+        int maxValue = application.type().maximumTerm();
+
+        if (term < minValue || term > maxValue) {
+            ApplicationTermOutOfBoundsException ex = new ApplicationTermOutOfBoundsException(minValue, maxValue);
+            logger.error("Loan term validation failed. Term: {}, Min: {}, Max: {}", term, minValue, maxValue, ex);
+
+            return Mono.just(ValidationOutcome.error(ApplicationFieldNames.TERM, ex.getMessage()));
+        }
+
+        logger.info("Loan term validation passed. Term: {}, Min: {}, Max: {}", term, minValue, maxValue);
+        return Mono.just(ValidationOutcome.success(ApplicationFieldNames.TERM));
+    }
+
+}

--- a/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/validation/ValidationLoanApplicationOrchestrator.java
+++ b/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/validation/ValidationLoanApplicationOrchestrator.java
@@ -1,0 +1,20 @@
+package co.com.pragma.crediya.usecase.loan.validation;
+
+import co.com.pragma.crediya.model.common.validation.ValidationOutcome;
+import co.com.pragma.crediya.model.loan.Application;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+public record ValidationLoanApplicationOrchestrator(
+        LoanAmountValidator loanAmountValidator,
+        LoanTermValidator loanTermValidator) {
+
+    public Mono<List<ValidationOutcome>> validateApplicationBusinessRules(Application application) {
+        return Mono.zip(
+                loanAmountValidator.validate(application),
+                loanTermValidator.validate(application)
+        ).map(tuple -> List.of(tuple.getT1(), tuple.getT2()));
+    }
+
+}

--- a/domain/usecase/src/test/java/co/com/pragma/crediya/usecase/loan/ApplicationUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/pragma/crediya/usecase/loan/ApplicationUseCaseTest.java
@@ -2,9 +2,12 @@ package co.com.pragma.crediya.usecase.loan;
 
 import co.com.pragma.crediya.model.StatusChange;
 import co.com.pragma.crediya.model.common.constants.DomainConstants;
+import co.com.pragma.crediya.model.common.validation.ValidationOutcome;
 import co.com.pragma.crediya.model.jwt.Jwt;
 import co.com.pragma.crediya.model.loan.*;
 import co.com.pragma.crediya.model.loan.constants.ApplicationConstants;
+import co.com.pragma.crediya.model.loan.constants.ApplicationErrorMessages;
+import co.com.pragma.crediya.model.loan.constants.ApplicationFieldNames;
 import co.com.pragma.crediya.model.loan.exceptions.*;
 import co.com.pragma.crediya.model.loan.gateways.ApplicationRepository;
 import co.com.pragma.crediya.model.loan.gateways.LoanValidationPort;
@@ -17,6 +20,7 @@ import co.com.pragma.crediya.model.notification.gateways.NotificationPort;
 import co.com.pragma.crediya.model.notification.gateways.NotificationRendererPort;
 import co.com.pragma.crediya.model.transaction.gateways.TransactionalPort;
 import co.com.pragma.crediya.model.user.User;
+import co.com.pragma.crediya.usecase.loan.validation.ValidationLoanApplicationOrchestrator;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,6 +53,9 @@ class ApplicationUseCaseTest {
     private ApplicationRepository applicationRepository;
 
     @Mock
+    private ValidationLoanApplicationOrchestrator validationLoanApplicationOrchestrator;
+
+    @Mock
     private NotificationPort notificationPort;
 
     @Mock
@@ -74,9 +81,13 @@ class ApplicationUseCaseTest {
 
     private Status status;
 
+    private List<ValidationOutcome> amountErrorValidations;
+
+    private List<ValidationOutcome> termErrorValidations;
+
     @BeforeEach
     void setUp() {
-        useCase = new ApplicationUseCase(typeRepository, statusRepository, applicationRepository, notificationPort, notificationRendererPort, loanValidationPort, logger, transactionalPort);
+        useCase = new ApplicationUseCase(typeRepository, statusRepository, applicationRepository, validationLoanApplicationOrchestrator, notificationPort, notificationRendererPort, loanValidationPort, logger, transactionalPort);
 
         User loggedUser = new User("1234567890", "jhondoe@example.com", BigDecimal.valueOf(1200000));
 
@@ -86,11 +97,29 @@ class ApplicationUseCaseTest {
 
         application = new Application(UUID.randomUUID(), BigDecimal.valueOf(4000000), 12, loggedUser.identificationNumber(), loggedUser.email(), type, status);
 
+        List<ValidationOutcome> successfulValidations = List.of(
+                ValidationOutcome.success(ApplicationFieldNames.AMOUNT),
+                ValidationOutcome.success(ApplicationFieldNames.TERM)
+        );
+
+        amountErrorValidations = List.of(
+                ValidationOutcome.error(ApplicationFieldNames.AMOUNT, "amount most be between 10.000.000,00 and 20.000.000,00"),
+                ValidationOutcome.success(ApplicationFieldNames.TERM)
+        );
+
+        termErrorValidations = List.of(
+                ValidationOutcome.success(ApplicationFieldNames.AMOUNT),
+                ValidationOutcome.error(ApplicationFieldNames.TERM, "term most be between  and ")
+        );
+
         lenient().when(transactionalPort.transactional(any(Mono.class))).then(returnsFirstArg());
 
         lenient().when(mockJwt.subject()).thenReturn(loggedUser.email());
 
         lenient().when(mockJwt.identificationNumber()).thenReturn(loggedUser.identificationNumber());
+
+        lenient().when(validationLoanApplicationOrchestrator.validateApplicationBusinessRules(any(Application.class)))
+                .thenReturn(Mono.just(successfulValidations));
 
         lenient().when(applicationRepository.findActiveLoansByIdentificationNumber(application.identificationNumber()))
                 .thenReturn(Flux.empty());
@@ -180,10 +209,43 @@ class ApplicationUseCaseTest {
 
         when(statusRepository.findByName(DomainConstants.DEFAULT_PENDING_STATUS)).thenReturn(Mono.just(status));
 
+        when(validationLoanApplicationOrchestrator.validateApplicationBusinessRules(any(Application.class)))
+                .thenReturn(Mono.just(amountErrorValidations));
+
         StepVerifier.create(useCase.save(application, mockJwt))
                 .expectErrorSatisfies(error -> assertThat(error)
-                        .isInstanceOf(ApplicationValueOutOfBoundsException.class)
-                        .hasMessage("amount most be between 10.000.000,00 and 20.000.000,00"))
+                        .isInstanceOf(ApplicationBusinessValidationException.class)
+                        .hasMessage(ApplicationErrorMessages.APPLICATION_BUSINESS_VALIDATION_FAILED))
+                .verify();
+
+        verify(typeRepository).findByName(DomainConstants.MICROCREDIT);
+
+        verify(statusRepository).findByName(DomainConstants.DEFAULT_PENDING_STATUS);
+    }
+
+    @Test
+    void saveApplicationFailsWhenTermOutOfRange() {
+        Type restrictedType = new Type(
+                UUID.randomUUID(),
+                DomainConstants.MICROCREDIT,
+                BigDecimal.valueOf(300000),
+                BigDecimal.valueOf(50000000),
+                24,
+                84,
+                BigDecimal.valueOf(25.00),
+                true
+        );
+        when(typeRepository.findByName(DomainConstants.MICROCREDIT)).thenReturn(Mono.just(restrictedType));
+
+        when(statusRepository.findByName(DomainConstants.DEFAULT_PENDING_STATUS)).thenReturn(Mono.just(status));
+
+        when(validationLoanApplicationOrchestrator.validateApplicationBusinessRules(any(Application.class)))
+                .thenReturn(Mono.just(termErrorValidations));
+
+        StepVerifier.create(useCase.save(application, mockJwt))
+                .expectErrorSatisfies(error -> assertThat(error)
+                        .isInstanceOf(ApplicationBusinessValidationException.class)
+                        .hasMessage(ApplicationErrorMessages.APPLICATION_BUSINESS_VALIDATION_FAILED))
                 .verify();
 
         verify(typeRepository).findByName(DomainConstants.MICROCREDIT);

--- a/domain/usecase/src/test/java/co/com/pragma/crediya/usecase/loan/ApplicationUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/pragma/crediya/usecase/loan/ApplicationUseCaseTest.java
@@ -1,18 +1,20 @@
 package co.com.pragma.crediya.usecase.loan;
 
+import co.com.pragma.crediya.model.StatusChange;
 import co.com.pragma.crediya.model.common.constants.DomainConstants;
 import co.com.pragma.crediya.model.jwt.Jwt;
-import co.com.pragma.crediya.model.loan.Application;
-import co.com.pragma.crediya.model.loan.Status;
-import co.com.pragma.crediya.model.loan.Type;
+import co.com.pragma.crediya.model.loan.*;
 import co.com.pragma.crediya.model.loan.constants.ApplicationConstants;
 import co.com.pragma.crediya.model.loan.exceptions.*;
 import co.com.pragma.crediya.model.loan.gateways.ApplicationRepository;
+import co.com.pragma.crediya.model.loan.gateways.LoanValidationPort;
 import co.com.pragma.crediya.model.loan.gateways.StatusRepository;
 import co.com.pragma.crediya.model.loan.gateways.TypeRepository;
 import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
+import co.com.pragma.crediya.model.notification.LoanApproval;
 import co.com.pragma.crediya.model.notification.NotificationMessage;
 import co.com.pragma.crediya.model.notification.gateways.NotificationPort;
+import co.com.pragma.crediya.model.notification.gateways.NotificationRendererPort;
 import co.com.pragma.crediya.model.transaction.gateways.TransactionalPort;
 import co.com.pragma.crediya.model.user.User;
 import org.junit.jupiter.api.Assertions;
@@ -21,10 +23,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -45,7 +49,13 @@ class ApplicationUseCaseTest {
     private ApplicationRepository applicationRepository;
 
     @Mock
-    NotificationPort notificationPort;
+    private NotificationPort notificationPort;
+
+    @Mock
+    private NotificationRendererPort notificationRendererPort;
+
+    @Mock
+    LoanValidationPort loanValidationPort;
 
     @Mock
     private LoggerPort logger;
@@ -66,11 +76,11 @@ class ApplicationUseCaseTest {
 
     @BeforeEach
     void setUp() {
-        useCase = new ApplicationUseCase(typeRepository, statusRepository, applicationRepository, notificationPort, logger, transactionalPort);
+        useCase = new ApplicationUseCase(typeRepository, statusRepository, applicationRepository, notificationPort, notificationRendererPort, loanValidationPort, logger, transactionalPort);
 
         User loggedUser = new User("1234567890", "jhondoe@example.com", BigDecimal.valueOf(1200000));
 
-        type = new Type(UUID.randomUUID(), DomainConstants.MICROCREDIT, BigDecimal.valueOf(300000), BigDecimal.valueOf(50000000), BigDecimal.valueOf(25.00), true);
+        type = new Type(UUID.randomUUID(), DomainConstants.MICROCREDIT, BigDecimal.valueOf(300000), BigDecimal.valueOf(50000000), 12, 24, BigDecimal.valueOf(25.00), true);
 
         status = new Status(UUID.randomUUID(), DomainConstants.DEFAULT_PENDING_STATUS, "Application received, under evaluation");
 
@@ -81,6 +91,18 @@ class ApplicationUseCaseTest {
         lenient().when(mockJwt.subject()).thenReturn(loggedUser.email());
 
         lenient().when(mockJwt.identificationNumber()).thenReturn(loggedUser.identificationNumber());
+
+        lenient().when(applicationRepository.findActiveLoansByIdentificationNumber(application.identificationNumber()))
+                .thenReturn(Flux.empty());
+
+        lenient().when(loanValidationPort.validateLoanAutomatically(any(ApplicationRiskEvaluation.class)))
+                .thenReturn(Mono.empty());
+
+        lenient().when(notificationRendererPort.processLoanApprovalTemplate(any(LoanApproval.class)))
+                .thenReturn(Mono.just("<html><body>CREDIYA</body></html>"));
+
+        lenient().when(notificationRendererPort.processStatusChangeTemplate(any(StatusChange.class)))
+                .thenReturn(Mono.just("<html><body>CREDIYA</body></html>"));
     }
 
     @Test
@@ -149,6 +171,8 @@ class ApplicationUseCaseTest {
                 DomainConstants.MICROCREDIT,
                 BigDecimal.valueOf(10000000),
                 BigDecimal.valueOf(20000000),
+                12,
+                24,
                 BigDecimal.valueOf(25.00),
                 true
         );
@@ -184,7 +208,7 @@ class ApplicationUseCaseTest {
 
         when(applicationRepository.save(any(Application.class))).thenReturn(Mono.just(application));
 
-        doNothing().when(notificationPort).sendNotification(any(NotificationMessage.class));
+        when(notificationPort.sendNotification(any(NotificationMessage.class))).thenReturn(Mono.empty());
 
         StepVerifier.create(useCase.processAndApproveOrReject(appId, newStatus))
                 .assertNext(updated -> {
@@ -217,7 +241,7 @@ class ApplicationUseCaseTest {
 
         when(applicationRepository.save(any(Application.class))).thenReturn(Mono.just(application));
 
-        doNothing().when(notificationPort).sendNotification(any(NotificationMessage.class));
+        when(notificationPort.sendNotification(any(NotificationMessage.class))).thenReturn(Mono.empty());
 
         StepVerifier.create(useCase.processAndApproveOrReject(appId, newStatus))
                 .assertNext(updated -> {
@@ -291,6 +315,71 @@ class ApplicationUseCaseTest {
         verify(applicationRepository).findById(appId);
 
         verify(applicationRepository, never()).save(any(Application.class));
+    }
+
+    @Test
+    void processApplicationStatusUpdateApprovedSuccessfully() {
+        UUID appId = application.id();
+
+        PaymentDetail paymentDetail = new PaymentDetail(1, BigDecimal.valueOf(500000), BigDecimal.valueOf(400000), BigDecimal.valueOf(100000), BigDecimal.valueOf(3500000));
+        LoanValidation loanValidation = new LoanValidation(appId, DomainConstants.APPROVED_STATUS, List.of(paymentDetail));
+
+        Status approved = new Status(UUID.randomUUID(), DomainConstants.APPROVED_STATUS, "Application approved");
+
+        when(statusRepository.findByName(DomainConstants.APPROVED_STATUS)).thenReturn(Mono.just(approved));
+
+        when(applicationRepository.findById(appId)).thenReturn(Mono.just(application));
+
+        when(typeRepository.findById(application.type().id())).thenReturn(Mono.just(type));
+
+        when(applicationRepository.save(any(Application.class))).thenReturn(Mono.just(application));
+
+        when(notificationPort.sendNotification(any(NotificationMessage.class))).thenReturn(Mono.empty());
+
+        StepVerifier.create(useCase.processApplicationStatusUpdate(loanValidation))
+                .verifyComplete();
+
+        verify(statusRepository).findByName(DomainConstants.APPROVED_STATUS);
+
+        verify(applicationRepository).findById(appId);
+
+        verify(applicationRepository).save(any(Application.class));
+
+        verify(notificationRendererPort).processLoanApprovalTemplate(any(LoanApproval.class));
+
+        verify(notificationPort).sendNotification(any(NotificationMessage.class));
+    }
+
+    @Test
+    void processApplicationStatusUpdateRejectedSuccessfully() {
+        UUID appId = application.id();
+
+        LoanValidation loanValidation = new LoanValidation(appId, DomainConstants.REJECTED_STATUS, List.of());
+
+        Status rejected = new Status(UUID.randomUUID(), DomainConstants.REJECTED_STATUS, "Application rejected");
+
+        when(statusRepository.findByName(DomainConstants.REJECTED_STATUS)).thenReturn(Mono.just(rejected));
+
+        when(applicationRepository.findById(appId)).thenReturn(Mono.just(application));
+
+        when(typeRepository.findById(application.type().id())).thenReturn(Mono.just(type));
+
+        when(applicationRepository.save(any(Application.class))).thenReturn(Mono.just(application));
+
+        when(notificationPort.sendNotification(any(NotificationMessage.class))).thenReturn(Mono.empty());
+
+        StepVerifier.create(useCase.processApplicationStatusUpdate(loanValidation))
+                .verifyComplete();
+
+        verify(statusRepository).findByName(DomainConstants.REJECTED_STATUS);
+
+        verify(applicationRepository).findById(appId);
+
+        verify(applicationRepository).save(any(Application.class));
+
+        verify(notificationRendererPort).processStatusChangeTemplate(any(StatusChange.class));
+
+        verify(notificationPort).sendNotification(any(NotificationMessage.class));
     }
 
 }

--- a/domain/usecase/src/test/java/co/com/pragma/crediya/usecase/loan/validation/LoanAmountValidatorTest.java
+++ b/domain/usecase/src/test/java/co/com/pragma/crediya/usecase/loan/validation/LoanAmountValidatorTest.java
@@ -1,0 +1,90 @@
+package co.com.pragma.crediya.usecase.loan.validation;
+
+import co.com.pragma.crediya.model.common.constants.DomainConstants;
+import co.com.pragma.crediya.model.common.validation.ValidationOutcome;
+import co.com.pragma.crediya.model.loan.Application;
+import co.com.pragma.crediya.model.loan.Status;
+import co.com.pragma.crediya.model.loan.Type;
+import co.com.pragma.crediya.model.loan.constants.ApplicationConstants;
+import co.com.pragma.crediya.model.loan.constants.ApplicationFieldNames;
+import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class LoanAmountValidatorTest {
+
+    @Mock
+    private LoggerPort logger;
+
+    private LoanAmountValidator validator;
+
+    private Type type;
+
+    private Status status;
+
+    private Application application;
+
+    @BeforeEach
+    void setUp() {
+        type = new Type(UUID.randomUUID(), DomainConstants.MICROCREDIT, BigDecimal.valueOf(300000), BigDecimal.valueOf(50000000), 12, 24, BigDecimal.valueOf(25.00), true);
+        status = new Status(UUID.randomUUID(), DomainConstants.DEFAULT_PENDING_STATUS, "Application received, under evaluation");
+
+        application = new Application(UUID.randomUUID(), BigDecimal.valueOf(4000000), 12, "1234567890", "johndoe@example.com", type, status);
+
+        validator = new LoanAmountValidator(logger);
+    }
+
+    @Test
+    void shouldReturnErrorWhenAmountIsLessThanMinimum() {
+        Application invalidApp = new Application(application.id(), BigDecimal.valueOf(200000), application.term(), application.identificationNumber(), application.email(), type, status);
+
+        ValidationOutcome outcome = validator.validate(invalidApp).block();
+
+        Assertions.assertNotNull(outcome);
+
+        assertThat(outcome.isValid()).isFalse();
+
+        assertThat(outcome.field()).isEqualTo(ApplicationFieldNames.AMOUNT);
+
+        assertThat(outcome.errorMessage()).contains(ApplicationConstants.MOST_BE_BETWEEN);
+    }
+
+    @Test
+    void shouldReturnErrorWhenAmountIsGreaterThanMaximum() {
+        Application invalidApp = new Application(application.id(), BigDecimal.valueOf(60000000), application.term(), application.identificationNumber(), application.email(), type, status);
+
+        ValidationOutcome outcome = validator.validate(invalidApp).block();
+
+        Assertions.assertNotNull(outcome);
+
+        assertThat(outcome.isValid()).isFalse();
+
+        assertThat(outcome.field()).isEqualTo(ApplicationFieldNames.AMOUNT);
+
+        assertThat(outcome.errorMessage()).contains(ApplicationConstants.MOST_BE_BETWEEN);
+    }
+
+
+    @Test
+    void shouldReturnSuccessWhenAmountIsWithinRange() {
+        ValidationOutcome outcome = validator.validate(application).block();
+
+        Assertions.assertNotNull(outcome);
+
+        assertThat(outcome.isValid()).isTrue();
+
+        assertThat(outcome.errorMessage()).isNull();
+    }
+
+}
+

--- a/domain/usecase/src/test/java/co/com/pragma/crediya/usecase/loan/validation/LoanTermValidatorTest.java
+++ b/domain/usecase/src/test/java/co/com/pragma/crediya/usecase/loan/validation/LoanTermValidatorTest.java
@@ -1,0 +1,89 @@
+package co.com.pragma.crediya.usecase.loan.validation;
+
+import co.com.pragma.crediya.model.common.constants.DomainConstants;
+import co.com.pragma.crediya.model.common.validation.ValidationOutcome;
+import co.com.pragma.crediya.model.loan.Application;
+import co.com.pragma.crediya.model.loan.Status;
+import co.com.pragma.crediya.model.loan.Type;
+import co.com.pragma.crediya.model.loan.constants.ApplicationConstants;
+import co.com.pragma.crediya.model.loan.constants.ApplicationFieldNames;
+import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class LoanTermValidatorTest {
+
+    @Mock
+    private LoggerPort logger;
+
+    private LoanTermValidator validator;
+
+    private Type type;
+
+    private Status status;
+
+    private Application application;
+
+    @BeforeEach
+    void setUp() {
+        type = new Type(UUID.randomUUID(), DomainConstants.MICROCREDIT, BigDecimal.valueOf(300000), BigDecimal.valueOf(50000000), 12, 24, BigDecimal.valueOf(25.00), true);
+        status = new Status(UUID.randomUUID(), DomainConstants.DEFAULT_PENDING_STATUS, "Application received, under evaluation");
+
+        application = new Application(UUID.randomUUID(), BigDecimal.valueOf(4000000), 15, "1234567890", "johndoe@example.com", type, status);
+
+        validator = new LoanTermValidator(logger);
+    }
+
+    @Test
+    void shouldReturnErrorWhenTermIsLessThanMinimum() {
+        Application invalidApp = new Application(application.id(), application.amount(), 10, application.identificationNumber(), application.email(), type, status);
+
+        ValidationOutcome outcome = validator.validate(invalidApp).block();
+
+        Assertions.assertNotNull(outcome);
+
+        assertThat(outcome.isValid()).isFalse();
+
+        assertThat(outcome.field()).isEqualTo(ApplicationFieldNames.TERM);
+
+        assertThat(outcome.errorMessage()).contains(ApplicationConstants.MOST_BE_BETWEEN);
+    }
+
+    @Test
+    void shouldReturnErrorWhenTermIsGreaterThanMaximum() {
+        Application invalidApp = new Application(application.id(), application.amount(), 25, application.identificationNumber(), application.email(), type, status);
+
+        ValidationOutcome outcome = validator.validate(invalidApp).block();
+
+        Assertions.assertNotNull(outcome);
+
+        assertThat(outcome.isValid()).isFalse();
+
+        assertThat(outcome.field()).isEqualTo(ApplicationFieldNames.TERM);
+
+        assertThat(outcome.errorMessage()).contains(ApplicationConstants.MOST_BE_BETWEEN);
+    }
+
+
+    @Test
+    void shouldReturnSuccessWhenTermIsWithinRange() {
+        ValidationOutcome outcome = validator.validate(application).block();
+
+        Assertions.assertNotNull(outcome);
+
+        assertThat(outcome.isValid()).isTrue();
+
+        assertThat(outcome.errorMessage()).isNull();
+    }
+
+}

--- a/domain/usecase/src/test/java/co/com/pragma/crediya/usecase/loan/validation/ValidationLoanApplicationOrchestratorTest.java
+++ b/domain/usecase/src/test/java/co/com/pragma/crediya/usecase/loan/validation/ValidationLoanApplicationOrchestratorTest.java
@@ -1,0 +1,56 @@
+package co.com.pragma.crediya.usecase.loan.validation;
+
+import co.com.pragma.crediya.model.common.constants.DomainConstants;
+import co.com.pragma.crediya.model.common.validation.ValidationOutcome;
+import co.com.pragma.crediya.model.loan.Application;
+import co.com.pragma.crediya.model.loan.Status;
+import co.com.pragma.crediya.model.loan.Type;
+import co.com.pragma.crediya.model.loan.constants.ApplicationFieldNames;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@ExtendWith(MockitoExtension.class)
+class ValidationLoanApplicationOrchestratorTest {
+
+    @Mock
+    private LoanAmountValidator loanAmountValidator;
+
+    @Mock
+    private LoanTermValidator loanTermValidator;
+
+    private ValidationLoanApplicationOrchestrator orchestrator;
+
+    @BeforeEach
+    void setUp() {
+        orchestrator = new ValidationLoanApplicationOrchestrator(loanAmountValidator, loanTermValidator);
+    }
+
+    @Test
+    void validate_shouldReturnValidationOutcomes() {
+        Type type = new Type(UUID.randomUUID(), DomainConstants.MICROCREDIT, BigDecimal.valueOf(300000), BigDecimal.valueOf(50000000), 12, 24, BigDecimal.valueOf(25.00), true);
+        Status status = new Status(UUID.randomUUID(), DomainConstants.DEFAULT_PENDING_STATUS, "Application received, under evaluation");
+
+        Application application = new Application(UUID.randomUUID(), BigDecimal.valueOf(4000000), 12, "1234567890", "johndoe@example.com", type, status);
+
+        ValidationOutcome amountOutcome = ValidationOutcome.success(ApplicationFieldNames.AMOUNT);
+        ValidationOutcome termOutcome = ValidationOutcome.success(ApplicationFieldNames.TERM);
+
+        Mockito.when(loanAmountValidator.validate(application)).thenReturn(Mono.just(amountOutcome));
+        Mockito.when(loanTermValidator.validate(application)).thenReturn(Mono.just(termOutcome));
+
+        StepVerifier.create(orchestrator.validateApplicationBusinessRules(application))
+                .expectNextMatches(list ->
+                        list.contains(amountOutcome) && list.contains(termOutcome)
+                ).verifyComplete();
+    }
+
+}

--- a/infrastructure/driven-adapters/jwt/src/main/java/co/com/pragma/crediya/jwt/JwtProviderAdapter.java
+++ b/infrastructure/driven-adapters/jwt/src/main/java/co/com/pragma/crediya/jwt/JwtProviderAdapter.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
+import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 
 @Component
@@ -27,8 +29,9 @@ public class JwtProviderAdapter implements JwtProviderPort {
         String subject = extractSubject(claims);
         List<String> roles = extractRole(claims);
         String identificationNumber = extractIdentificationNumber(claims);
+        BigDecimal baseSalary = extractBaseSalary(claims);
 
-        return new Jwt(subject, roles, identificationNumber);
+        return new Jwt(subject, roles, identificationNumber, baseSalary);
     }
 
     private SecretKey getSecretKey() {
@@ -48,11 +51,18 @@ public class JwtProviderAdapter implements JwtProviderPort {
 
     @SuppressWarnings("unchecked")
     private List<String> extractRole(Claims claims) {
-        return (List<String>) claims.get(UserFieldNames.ROLES);
+        Object value = claims.get(UserFieldNames.ROLES);
+        return value != null ? (List<String>) value : Collections.emptyList();
     }
 
     private String extractIdentificationNumber(Claims claims) {
-        return claims.get(UserFieldNames.IDENTIFICATION_NUMBER).toString();
+        Object value = claims.get(UserFieldNames.IDENTIFICATION_NUMBER);
+        return value != null ? value.toString() : "";
+    }
+
+    private BigDecimal extractBaseSalary(Claims claims) {
+        Object value = claims.get(UserFieldNames.BASE_SALARY);
+        return value != null ? new BigDecimal(value.toString()) : BigDecimal.ZERO;
     }
 
     private String extractSubject(Claims claims) {

--- a/infrastructure/driven-adapters/jwt/src/test/java/co/com/pragma/crediya/jwt/JwtProviderAdapterTest.java
+++ b/infrastructure/driven-adapters/jwt/src/test/java/co/com/pragma/crediya/jwt/JwtProviderAdapterTest.java
@@ -42,6 +42,7 @@ class JwtProviderAdapterTest {
                 .subject(user.email())
                 .claim(UserFieldNames.ROLES, List.of(DomainConstants.ADMIN_ROLE))
                 .claim(UserFieldNames.IDENTIFICATION_NUMBER, user.identificationNumber())
+                .claim(UserFieldNames.BASE_SALARY, user.baseSalary())
                 .signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(properties.getSecretKey())))
                 .compact();
 
@@ -51,6 +52,7 @@ class JwtProviderAdapterTest {
         assertThat(jwt.subject()).isEqualTo(user.email());
         assertThat(jwt.roles()).containsExactly(DomainConstants.ADMIN_ROLE);
         assertThat(jwt.identificationNumber()).isEqualTo(user.identificationNumber());
+        assertThat(jwt.baseSalary()).isEqualTo(user.baseSalary());
     }
 
 }

--- a/infrastructure/driven-adapters/mustache-template/build.gradle
+++ b/infrastructure/driven-adapters/mustache-template/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    implementation project(':model')
+    implementation 'org.springframework:spring-context'
+
+    // Mustache Template Engine
+    implementation 'com.github.spullara.mustache.java:compiler:0.9.14'
+}

--- a/infrastructure/driven-adapters/mustache-template/src/main/java/co/com/pragma/crediya/mustachetemplate/MustacheTemplateAdapter.java
+++ b/infrastructure/driven-adapters/mustache-template/src/main/java/co/com/pragma/crediya/mustachetemplate/MustacheTemplateAdapter.java
@@ -1,0 +1,80 @@
+package co.com.pragma.crediya.mustachetemplate;
+
+
+import co.com.pragma.crediya.model.StatusChange;
+import co.com.pragma.crediya.model.notification.LoanApproval;
+import co.com.pragma.crediya.model.notification.gateways.NotificationRendererPort;
+import co.com.pragma.crediya.mustachetemplate.constants.MustacheTemplates;
+import co.com.pragma.crediya.mustachetemplate.formatters.CurrencyFormatter;
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
+import com.github.mustachejava.MustacheFactory;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class MustacheTemplateAdapter implements NotificationRendererPort {
+
+    private final MustacheFactory mf = new DefaultMustacheFactory("templates");
+
+    private final CurrencyFormatter currencyFormatter;
+
+    public MustacheTemplateAdapter() {
+        this.currencyFormatter = new CurrencyFormatter();
+    }
+
+    @Override
+    public Mono<String> processLoanApprovalTemplate(LoanApproval template) {
+        return Mono.fromCallable(() -> {
+            Mustache mustache = this.mf.compile(MustacheTemplates.LOAN_PAYMENT_PLAN);
+
+            Map<String, Object> context = new HashMap<>();
+            context.put("loanType", template.loanType());
+            context.put("amount", currencyFormatter.format(template.amount()));
+            context.put("term", template.term());
+            context.put("interestRate", template.interestRate());
+            context.put("monthlyPayment", currencyFormatter.format(template.monthlyPayment()));
+
+            List<Map<String, Object>> paymentDetail = template.paymentDetail().stream()
+                    .map(detail -> {
+                        Map<String, Object> map = new HashMap<>();
+                        map.put("month", detail.month());
+                        map.put("installment", currencyFormatter.format(detail.installment()));
+                        map.put("principal", currencyFormatter.format(detail.principal()));
+                        map.put("interest", currencyFormatter.format(detail.interest()));
+                        map.put("balance", currencyFormatter.format(detail.balance()));
+                        return map;
+                    })
+                    .toList();
+
+            context.put("paymentDetail", paymentDetail);
+
+            StringWriter writer = new StringWriter();
+            mustache.execute(writer, context).flush();
+            return writer.toString();
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+    @Override
+    public Mono<String> processStatusChangeTemplate(StatusChange statusChange) {
+        return Mono.fromCallable(() -> {
+            Mustache mustache = this.mf.compile(MustacheTemplates.STATUS_CHANGE);
+
+            Map<String, Object> context = new HashMap<>();
+            context.put("status", statusChange.status());
+            context.put("loanType", statusChange.loanType());
+            context.put("amount", currencyFormatter.format(statusChange.amount()));
+
+            StringWriter writer = new StringWriter();
+            mustache.execute(writer, context).flush();
+            return writer.toString();
+        }).subscribeOn(Schedulers.boundedElastic());
+    }
+
+}

--- a/infrastructure/driven-adapters/mustache-template/src/main/java/co/com/pragma/crediya/mustachetemplate/constants/MustacheTemplates.java
+++ b/infrastructure/driven-adapters/mustache-template/src/main/java/co/com/pragma/crediya/mustachetemplate/constants/MustacheTemplates.java
@@ -1,0 +1,12 @@
+package co.com.pragma.crediya.mustachetemplate.constants;
+
+public final class MustacheTemplates {
+
+    private MustacheTemplates() {
+    }
+
+    public static final String STATUS_CHANGE = "status-change.mustache";
+
+    public static final String LOAN_PAYMENT_PLAN = "loan-payment-plan.mustache";
+
+}

--- a/infrastructure/driven-adapters/mustache-template/src/main/java/co/com/pragma/crediya/mustachetemplate/formatters/CurrencyFormatter.java
+++ b/infrastructure/driven-adapters/mustache-template/src/main/java/co/com/pragma/crediya/mustachetemplate/formatters/CurrencyFormatter.java
@@ -1,0 +1,28 @@
+package co.com.pragma.crediya.mustachetemplate.formatters;
+
+import java.math.BigDecimal;
+import java.text.NumberFormat;
+import java.util.Locale;
+
+public class CurrencyFormatter {
+
+    private final NumberFormat formatter;
+
+    public CurrencyFormatter(Locale locale) {
+        this.formatter = NumberFormat.getCurrencyInstance(locale);
+    }
+
+    public CurrencyFormatter() {
+        this(Locale.forLanguageTag("es-CO"));
+    }
+
+    public String format(BigDecimal value) {
+        if (value == null) {
+            value = BigDecimal.ZERO;
+        }
+
+        synchronized (formatter) {
+            return formatter.format(value);
+        }
+    }
+}

--- a/infrastructure/driven-adapters/mustache-template/src/main/resources/templates/loan-payment-plan.mustache
+++ b/infrastructure/driven-adapters/mustache-template/src/main/resources/templates/loan-payment-plan.mustache
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Loan Payment Plan</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+            color: #333;
+        }
+
+        h1 {
+            text-align: center;
+            margin-bottom: 10px;
+        }
+
+        p {
+            font-size: 14px;
+            margin-bottom: 15px;
+        }
+
+        ul {
+            font-size: 14px;
+            margin-bottom: 20px;
+        }
+
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 20px;
+            font-size: 14px;
+        }
+
+        th,
+        td {
+            border: 1px solid #ccc;
+            padding: 8px;
+            text-align: right;
+        }
+
+        th {
+            background-color: #f5f5f5;
+        }
+
+        td:first-child,
+        th:first-child {
+            text-align: center;
+        }
+    </style>
+</head>
+
+<body>
+    <h1>Crediya 💜 | Loan Payment Plan</h1>
+
+    <p>Hello,</p>
+    <p>The state of your loan application has been approved. Here are the details:</p>
+    <ul>
+        <li><strong>Loan Type:</strong> <span>{{loanType}}</span></li>
+        <li><strong>Amount:</strong> <span>{{amount}}</span></li>
+        <li><strong>Term:</strong> <span>{{term}} months</span></li>
+        <li><strong>Interest Rate:</strong> <span>{{interestRate}}%</span></li>
+    </ul>
+
+    <p>
+        Your fixed monthly installment is <strong>{{monthlyPayment}}</strong> for <strong>{{term}}</strong> months.
+        Below is the breakdown of each payment into principal and interest:
+    </p>
+
+    <table>
+        <thead>
+            <tr>
+                <th>Month</th>
+                <th>Installment</th>
+                <th>Principal</th>
+                <th>Interest</th>
+                <th>Balance</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{#paymentDetail}}
+                <tr>
+                    <td>{{month}}</td>
+                    <td>{{installment}}</td>
+                    <td>{{principal}}</td>
+                    <td>{{interest}}</td>
+                    <td>{{balance}}</td>
+                </tr>
+            {{/paymentDetail}}
+        </tbody>
+    </table>
+
+    <p>
+        Thank you for choosing Crediya! Please ensure timely payments to maintain a good credit standing.
+        If you have any questions about your loan plan, feel free to contact our support team.
+    </p>
+</body>
+
+</html>

--- a/infrastructure/driven-adapters/mustache-template/src/main/resources/templates/status-change.mustache
+++ b/infrastructure/driven-adapters/mustache-template/src/main/resources/templates/status-change.mustache
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Loan Status Update</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+            color: #333;
+        }
+
+        h1 {
+            text-align: center;
+            margin-bottom: 10px;
+        }
+
+        p {
+            font-size: 14px;
+            margin-bottom: 15px;
+        }
+
+        .status-box {
+            background-color: #f8f9fa;
+            border: 1px solid #dee2e6;
+            border-radius: 5px;
+            padding: 15px;
+            margin: 20px 0;
+            text-align: center;
+        }
+
+        .status-message {
+            font-size: 16px;
+            font-weight: bold;
+        }
+
+        ul {
+            font-size: 14px;
+            margin-bottom: 20px;
+        }
+    </style>
+</head>
+
+<body>
+    <h1>Crediya 💜 | Loan Status Update</h1>
+    <p>Hello,</p>
+
+    <div class="status-box">
+        <p class="status-message">Your loan application has been {{status}}.</p>
+    </div>
+
+    <p>Here are the details of your application:</p>
+    <ul>
+        <li><strong>Loan Type:</strong> <span>{{loanType}}</span></li>
+        <li><strong>Amount:</strong> <span>{{amount}}</span></li>
+    </ul>
+
+    <p>
+        If you have any questions about your application status, please don't hesitate to contact our support team.
+    </p>
+
+    <p>
+        Thank you for choosing Crediya!
+    </p>
+</body>
+
+</html>

--- a/infrastructure/driven-adapters/mustache-template/src/test/java/co/com/pragma/crediya/mustachetemplate/MustacheTemplateAdapterTest.java
+++ b/infrastructure/driven-adapters/mustache-template/src/test/java/co/com/pragma/crediya/mustachetemplate/MustacheTemplateAdapterTest.java
@@ -1,0 +1,67 @@
+package co.com.pragma.crediya.mustachetemplate;
+
+import co.com.pragma.crediya.model.StatusChange;
+import co.com.pragma.crediya.model.common.constants.DomainConstants;
+import co.com.pragma.crediya.model.loan.PaymentDetail;
+import co.com.pragma.crediya.model.notification.LoanApproval;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class MustacheTemplateAdapterTest {
+
+    private MustacheTemplateAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+        adapter = new MustacheTemplateAdapter();
+    }
+
+    @Test
+    void processStatusChangeTemplateSuccessfully() {
+        StatusChange statusChange = new StatusChange(DomainConstants.APPROVED_STATUS, DomainConstants.MICROCREDIT, BigDecimal.valueOf(5000000));
+
+        StepVerifier.create(adapter.processStatusChangeTemplate(statusChange))
+                .assertNext(html -> {
+                    assertThat(html).isNotNull();
+                    assertThat(html).isNotEmpty();
+                    assertThat(html).contains(DomainConstants.APPROVED_STATUS);
+                    assertThat(html).contains(DomainConstants.MICROCREDIT);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void processLoanApprovalTemplateSuccessfully() {
+        PaymentDetail payment1 = new PaymentDetail(1, BigDecimal.valueOf(500000), BigDecimal.valueOf(400000), BigDecimal.valueOf(100000), BigDecimal.valueOf(4500000));
+        PaymentDetail payment2 = new PaymentDetail(2, BigDecimal.valueOf(500000), BigDecimal.valueOf(420000), BigDecimal.valueOf(80000), BigDecimal.valueOf(4080000));
+
+        LoanApproval loanApproval = new LoanApproval(
+                DomainConstants.MICROCREDIT,
+                BigDecimal.valueOf(5000000),
+                12,
+                BigDecimal.valueOf(2.08),
+                BigDecimal.valueOf(500000),
+                List.of(payment1, payment2)
+        );
+
+        StepVerifier.create(adapter.processLoanApprovalTemplate(loanApproval))
+                .assertNext(html -> {
+                    assertThat(html).isNotNull();
+                    assertThat(html).isNotEmpty();
+                    assertThat(html).contains(DomainConstants.MICROCREDIT);
+                    assertThat(html).contains("12");
+                    assertThat(html).contains("2.08");
+                })
+                .verifyComplete();
+    }
+
+}

--- a/infrastructure/driven-adapters/mustache-template/src/test/resources/templates/loan-payment-plan.mustache
+++ b/infrastructure/driven-adapters/mustache-template/src/test/resources/templates/loan-payment-plan.mustache
@@ -1,0 +1,28 @@
+<html>
+<body>
+    <h1>Payment plan approved</h1>
+    <p>Loan Type: {{loanType}}</p>
+    <p>Amount: {{amount}}</p>
+    <p>Term: {{term}} months</p>
+    <p>Interest Rate: {{interestRate}}%</p>
+    <p>Installment: {{monthlyPayment}}</p>
+    <table>
+        <tr>
+            <th>Month</th>
+            <th>Installment</th>
+            <th>Principal</th>
+            <th>Interest</th>
+            <th>Balance</th>
+        </tr>
+        {{#paymentDetail}}
+            <tr>
+                <td>{{month}}</td>
+                <td>{{installment}}</td>
+                <td>{{principal}}</td>
+                <td>{{interest}}</td>
+                <td>{{balance}}</td>
+            </tr>
+        {{/paymentDetail}}
+    </table>
+</body>
+</html>

--- a/infrastructure/driven-adapters/mustache-template/src/test/resources/templates/status-change.mustache
+++ b/infrastructure/driven-adapters/mustache-template/src/test/resources/templates/status-change.mustache
@@ -1,0 +1,7 @@
+<html>
+    <body>
+        <h1>Loan Status: {{status}}</h1>
+        <p>Loan Type: {{loanType}}</p>
+        <p>Amount: {{amount}}</p>
+    </body>
+</html>

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/LoanApplicationReactiveRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/LoanApplicationReactiveRepository.java
@@ -56,5 +56,4 @@ public interface LoanApplicationReactiveRepository
             """)
     Flux<LoanAmortizationProjection> queryActiveLoansByIdentificationNumber(String identificationNumber);
 
-
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/LoanApplicationReactiveRepository.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/LoanApplicationReactiveRepository.java
@@ -1,6 +1,7 @@
 package co.com.pragma.crediya.r2dbc;
 
 import co.com.pragma.crediya.r2dbc.entity.LoanApplicationEntity;
+import co.com.pragma.crediya.r2dbc.projection.LoanAmortizationProjection;
 import co.com.pragma.crediya.r2dbc.projection.LoanApplicationProjection;
 import co.com.pragma.crediya.r2dbc.reports.LoanApplicationCustomRepository;
 import org.springframework.data.r2dbc.repository.Query;
@@ -42,5 +43,18 @@ public interface LoanApplicationReactiveRepository
                 WHERE S.name IN ('UNDER REVIEW', 'MANUAL REVIEW', 'REJECTED')
             """)
     Mono<Long> countLoanApplications();
+
+    @Query("""
+            SELECT
+                LA.amount,
+                LA.term,
+                T.interest_rate
+            FROM loan_application AS LA
+            JOIN loan_type AS T ON T.id = LA.type_id
+            JOIN loan_status S ON LA.status_id = S.id AND S.name = 'APPROVED'
+            WHERE LA.identification_number = :identificationNumber
+            """)
+    Flux<LoanAmortizationProjection> queryActiveLoansByIdentificationNumber(String identificationNumber);
+
 
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/LoanApplicationRepositoryAdapter.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/LoanApplicationRepositoryAdapter.java
@@ -1,5 +1,6 @@
 package co.com.pragma.crediya.r2dbc;
 
+import co.com.pragma.crediya.model.loan.ActiveApplication;
 import co.com.pragma.crediya.model.loan.Application;
 import co.com.pragma.crediya.model.loan.gateways.ApplicationRepository;
 import co.com.pragma.crediya.model.loan.report.ApplicationReport;
@@ -57,6 +58,12 @@ public class LoanApplicationRepositoryAdapter implements ApplicationRepository {
     @Override
     public Mono<Long> countLoanApplications(LoanApplicationFilter filter) {
         return loanApplicationReactiveRepository.countLoanApplications(filter);
+    }
+
+    @Override
+    public Flux<ActiveApplication> findActiveLoansByIdentificationNumber(String identificationNumber) {
+        return loanApplicationReactiveRepository.queryActiveLoansByIdentificationNumber(identificationNumber)
+                .map(loanApplicationMapper::toDomain);
     }
 
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/entity/LoanTypeEntity.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/entity/LoanTypeEntity.java
@@ -26,6 +26,10 @@ public class LoanTypeEntity {
 
     private BigDecimal maximumAmount;
 
+    private int minimumTerm;
+
+    private int maximumTerm;
+
     private BigDecimal interestRate;
 
     private Boolean automaticValidation;

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/mapper/LoanApplicationMapper.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/mapper/LoanApplicationMapper.java
@@ -1,8 +1,10 @@
 package co.com.pragma.crediya.r2dbc.mapper;
 
+import co.com.pragma.crediya.model.loan.ActiveApplication;
 import co.com.pragma.crediya.model.loan.Application;
 import co.com.pragma.crediya.model.loan.report.ApplicationReport;
 import co.com.pragma.crediya.r2dbc.entity.LoanApplicationEntity;
+import co.com.pragma.crediya.r2dbc.projection.LoanAmortizationProjection;
 import co.com.pragma.crediya.r2dbc.projection.LoanApplicationProjection;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
@@ -16,6 +18,8 @@ public interface LoanApplicationMapper {
     Application toDomain(LoanApplicationEntity loanApplicationEntity);
 
     ApplicationReport toDomain(LoanApplicationProjection loanApplicationProjection);
+
+    ActiveApplication toDomain(LoanAmortizationProjection loanAmortizationProjection);
 
     @Mapping(source = "type.id", target = "typeId")
     @Mapping(source = "status.id", target = "statusId")

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/projection/LoanAmortizationProjection.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/java/co/com/pragma/crediya/r2dbc/projection/LoanAmortizationProjection.java
@@ -1,0 +1,9 @@
+package co.com.pragma.crediya.r2dbc.projection;
+
+import java.math.BigDecimal;
+
+public record LoanAmortizationProjection(
+        BigDecimal amount,
+        Integer term,
+        BigDecimal interestRate) {
+}

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/main/resources/db/migration/V1__create_loan_type_and_loan_application_and_loan_status_tables.sql
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/main/resources/db/migration/V1__create_loan_type_and_loan_application_and_loan_status_tables.sql
@@ -4,6 +4,8 @@ CREATE TABLE loan_type
     name                 VARCHAR(100) UNIQUE NOT NULL,
     minimum_amount       NUMERIC(15, 2)      NOT NULL,
     maximum_amount       NUMERIC(15, 2)      NOT NULL,
+    minimum_term         INT                 NOT NULL,
+    maximum_term         INT                 NOT NULL,
     interest_rate        NUMERIC(5, 2)       NOT NULL,
     automatic_validation BOOLEAN             NOT NULL DEFAULT FALSE
 );
@@ -26,13 +28,13 @@ CREATE TABLE loan_application
     status_id             UUID           NOT NULL
 );
 
-INSERT INTO loan_type (name, minimum_amount, maximum_amount, interest_rate, automatic_validation)
-VALUES ('PERSONAL LOAN', 500000, 100000000, 18.50, TRUE),
-       ('MORTGAGE LOAN', 30000000, 1000000000, 12.00, FALSE),
-       ('AUTO LOAN', 10000000, 200000000, 14.00, TRUE),
-       ('PERSONAL UNSECURED LOAN', 1000000, 80000000, 20.00, TRUE),
-       ('EDUCATION LOAN', 500000, 50000000, 10.50, TRUE),
-       ('MICROCREDIT', 300000, 50000000, 25.00, TRUE);
+INSERT INTO loan_type (name, minimum_amount, maximum_amount, minimum_term, maximum_term, interest_rate, automatic_validation)
+VALUES ('PERSONAL LOAN', 500000, 100000000, 24, 72, 18.50, TRUE),
+       ('MORTGAGE LOAN', 30000000, 1000000000, 120, 360, 12.00, FALSE),
+       ('AUTO LOAN', 10000000, 200000000, 24, 84,  14.00, TRUE),
+       ('PERSONAL UNSECURED LOAN', 1000000, 80000000, 12, 60, 20.00, TRUE),
+       ('EDUCATION LOAN', 500000, 50000000, 24, 180, 10.50, TRUE),
+       ('MICROCREDIT', 300000, 50000000, 12, 36, 25.00, TRUE);
 
 INSERT INTO loan_status (name, description)
 VALUES ('UNDER REVIEW', 'Application received, under evaluation'),

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/pragma/crediya/r2dbc/LoanApplicationRepositoryAdapterTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/pragma/crediya/r2dbc/LoanApplicationRepositoryAdapterTest.java
@@ -1,11 +1,13 @@
 package co.com.pragma.crediya.r2dbc;
 
 import co.com.pragma.crediya.model.common.constants.DomainConstants;
+import co.com.pragma.crediya.model.loan.ActiveApplication;
 import co.com.pragma.crediya.model.loan.Application;
 import co.com.pragma.crediya.model.loan.report.ApplicationReport;
 import co.com.pragma.crediya.model.loan.report.LoanApplicationFilter;
 import co.com.pragma.crediya.r2dbc.entity.LoanApplicationEntity;
 import co.com.pragma.crediya.r2dbc.mapper.LoanApplicationMapper;
+import co.com.pragma.crediya.r2dbc.projection.LoanAmortizationProjection;
 import co.com.pragma.crediya.r2dbc.projection.LoanApplicationProjection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -82,6 +84,22 @@ class LoanApplicationRepositoryAdapterTest {
                 5,
                 1
         );
+    }
+
+    @Test
+    void findById_ShouldReturnApplication_WhenEntityExists() {
+        when(reactiveRepository.findById(application.id()))
+                .thenReturn(Mono.just(loanApplicationEntity));
+
+        when(mapper.toDomain(loanApplicationEntity)).thenReturn(application);
+
+        StepVerifier.create(adapter.findById(application.id()))
+                .expectNext(application)
+                .verifyComplete();
+
+        verify(reactiveRepository).findById(application.id());
+
+        verify(mapper).toDomain(loanApplicationEntity);
     }
 
     @Test
@@ -173,6 +191,26 @@ class LoanApplicationRepositoryAdapterTest {
                 .verifyComplete();
 
         verify(reactiveRepository).countLoanApplications(filter);
+    }
+
+    @Test
+    void findActiveLoansByIdentificationNumber_ShouldReturnActiveApplications_WhenEntitiesExist() {
+        ActiveApplication activeApplication = new ActiveApplication(BigDecimal.valueOf(1000000), 12, BigDecimal.valueOf(20.5));
+
+        LoanAmortizationProjection projection = new LoanAmortizationProjection(activeApplication.amount(), activeApplication.term(), activeApplication.interestRate());
+
+        when(reactiveRepository.queryActiveLoansByIdentificationNumber(application.identificationNumber()))
+                .thenReturn(Flux.just(projection));
+
+        when(mapper.toDomain(projection)).thenReturn(activeApplication);
+
+        StepVerifier.create(adapter.findActiveLoansByIdentificationNumber(application.identificationNumber()))
+                .expectNext(activeApplication)
+                .verifyComplete();
+
+        verify(reactiveRepository).queryActiveLoansByIdentificationNumber(application.identificationNumber());
+
+        verify(mapper).toDomain(projection);
     }
 
 }

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/pragma/crediya/r2dbc/LoanTypeRepositoryAdapterTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/pragma/crediya/r2dbc/LoanTypeRepositoryAdapterTest.java
@@ -36,8 +36,8 @@ class LoanTypeRepositoryAdapterTest {
 
     @BeforeEach
     void setUp() {
-        type = new Type(UUID.randomUUID(), DomainConstants.MICROCREDIT, BigDecimal.valueOf(300000), BigDecimal.valueOf(50000000), BigDecimal.valueOf(25.00), true);
-        loanTypeEntity = new LoanTypeEntity(type.id(), type.name(), type.minimumAmount(), type.maximumAmount(), type.interestRate(), type.automaticValidation());
+        type = new Type(UUID.randomUUID(), DomainConstants.MICROCREDIT, BigDecimal.valueOf(300000), BigDecimal.valueOf(50000000), 12, 36, BigDecimal.valueOf(25.00), true);
+        loanTypeEntity = new LoanTypeEntity(type.id(), type.name(), type.minimumAmount(), type.maximumAmount(), type.minimumTerm(), type.maximumTerm(), type.interestRate(), type.automaticValidation());
     }
 
     @Test

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/pragma/crediya/r2dbc/mapper/LoanApplicationMapperTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/pragma/crediya/r2dbc/mapper/LoanApplicationMapperTest.java
@@ -62,7 +62,7 @@ class LoanApplicationMapperTest {
 
     @Test
     void toEntity_fromApplication() {
-        Type type = new Type(UUID.randomUUID(), DomainConstants.MICROCREDIT, BigDecimal.valueOf(5.5), null, null, null);
+        Type type = new Type(UUID.randomUUID(), DomainConstants.MICROCREDIT, BigDecimal.valueOf(1000), BigDecimal.valueOf(2000), 12, 34, null, null);
         Status status = new Status(UUID.randomUUID(), DomainConstants.DEFAULT_PENDING_STATUS, "Default status");
 
         Application application = new Application(UUID.randomUUID(), BigDecimal.valueOf(1500), 18, "123456789", "johndoe@example.com", type, status);

--- a/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/pragma/crediya/r2dbc/mapper/LoanTypeMapperTest.java
+++ b/infrastructure/driven-adapters/r2dbc-postgresql/src/test/java/co/com/pragma/crediya/r2dbc/mapper/LoanTypeMapperTest.java
@@ -25,9 +25,11 @@ class LoanTypeMapperTest {
     void toDomain_fromEntity() {
         LoanTypeEntity entity = LoanTypeEntity.builder()
                 .id(UUID.randomUUID())
-                .name(DomainConstants.DEFAULT_PENDING_STATUS)
+                .name(DomainConstants.MICROCREDIT)
                 .minimumAmount(BigDecimal.valueOf(1000))
                 .maximumAmount(BigDecimal.valueOf(5000))
+                .minimumTerm(12)
+                .maximumTerm(36)
                 .interestRate(BigDecimal.valueOf(5.5))
                 .automaticValidation(true)
                 .build();
@@ -39,6 +41,8 @@ class LoanTypeMapperTest {
         assertThat(type.name()).isEqualTo(entity.getName());
         assertThat(type.minimumAmount()).isEqualTo(entity.getMinimumAmount());
         assertThat(type.maximumAmount()).isEqualTo(entity.getMaximumAmount());
+        assertThat(type.minimumTerm()).isEqualTo(entity.getMinimumTerm());
+        assertThat(type.maximumTerm()).isEqualTo(entity.getMaximumTerm());
         assertThat(type.interestRate()).isEqualTo(entity.getInterestRate());
         assertThat(type.automaticValidation()).isEqualTo(entity.getAutomaticValidation());
     }

--- a/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/pragma/crediya/consumer/UserServiceClient.java
+++ b/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/pragma/crediya/consumer/UserServiceClient.java
@@ -31,7 +31,6 @@ public class UserServiceClient implements UserPort {
     public Mono<List<User>> getUsersByEmails(Set<String> emails) {
         EmailsRequest request = new EmailsRequest(new ArrayList<>(emails));
 
-
         return webClient
                 .post()
                 .uri("/api/v1/users/search")

--- a/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/pragma/crediya/consumer/dto/UserResponse.java
+++ b/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/pragma/crediya/consumer/dto/UserResponse.java
@@ -13,6 +13,8 @@ import java.math.BigDecimal;
 @Builder
 public class UserResponse {
 
+    private String identificationNumber;
+
     private String email;
 
     private BigDecimal baseSalary;

--- a/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/pragma/crediya/consumer/mapper/UserExternalMapper.java
+++ b/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/pragma/crediya/consumer/mapper/UserExternalMapper.java
@@ -3,12 +3,10 @@ package co.com.pragma.crediya.consumer.mapper;
 import co.com.pragma.crediya.consumer.dto.UserResponse;
 import co.com.pragma.crediya.model.user.User;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface UserExternalMapper {
 
-    @Mapping(target = "identificationNumber", ignore = true)
     User toDomain(UserResponse userResponse);
 
 }

--- a/infrastructure/driven-adapters/rest-consumer/src/test/java/co/com/pragma/crediya/consumer/UserServiceClientTest.java
+++ b/infrastructure/driven-adapters/rest-consumer/src/test/java/co/com/pragma/crediya/consumer/UserServiceClientTest.java
@@ -63,8 +63,8 @@ class UserServiceClientTest {
 
     @Test
     void getUsersByEmails_shouldReturnMappedUsers() throws JsonProcessingException {
-        UserResponse john = new UserResponse("john@example.com", BigDecimal.valueOf(10000));
-        UserResponse jane = new UserResponse("jane@example.com", BigDecimal.valueOf(20000));
+        UserResponse john = new UserResponse(null,"john@example.com", BigDecimal.valueOf(10000));
+        UserResponse jane = new UserResponse(null, "jane@example.com", BigDecimal.valueOf(20000));
 
         mockWebServer.enqueue(new MockResponse()
                 .setBody(objectMapper.writeValueAsString(List.of(john, jane)))

--- a/infrastructure/driven-adapters/sqs-sender/build.gradle
+++ b/infrastructure/driven-adapters/sqs-sender/build.gradle
@@ -3,4 +3,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-autoconfigure'
     implementation 'org.apache.logging.log4j:log4j-api'
     implementation 'software.amazon.awssdk:sqs'
+
+    // ObjectMapper
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 }

--- a/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/crediya/sqs/sender/SQSSender.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/crediya/sqs/sender/SQSSender.java
@@ -1,8 +1,14 @@
 package co.com.pragma.crediya.sqs.sender;
 
+import co.com.pragma.crediya.model.loan.ApplicationRiskEvaluation;
+import co.com.pragma.crediya.model.loan.gateways.LoanValidationPort;
 import co.com.pragma.crediya.model.notification.NotificationMessage;
 import co.com.pragma.crediya.model.notification.gateways.NotificationPort;
 import co.com.pragma.crediya.sqs.sender.config.SQSSenderProperties;
+import co.com.pragma.crediya.sqs.sender.exceptions.LoanSerializationException;
+import co.com.pragma.crediya.sqs.sender.exceptions.NotificationSerializationException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
@@ -14,35 +20,52 @@ import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 @Service
 @Log4j2
 @RequiredArgsConstructor
-public class SQSSender implements NotificationPort {
+public class SQSSender implements NotificationPort, LoanValidationPort {
 
     private final SQSSenderProperties properties;
 
     private final SqsAsyncClient client;
 
+    private final ObjectMapper objectMapper;
+
     @Override
-    public void sendNotification(NotificationMessage message) {
-        String json = message.toJson();
+    public Mono<Void> sendNotification(NotificationMessage message) {
+        log.info("Sending email notification to SQS for recipient: [{}] : {}", message.to(), message);
 
-        log.info("Sending email notification to SQS for recipient: [{}] : {}", message.to(), json);
+        String queueUrl = properties.queueUrl() + properties.loanNotificationQueueName();
 
-        send(json)
-                .subscribe(
-                        messageId -> log.info("Email notification for {} queued successfully with Message ID: {}", message.to(), messageId),
-                        error -> log.error("Failed to send email notification to SQS for recipient: {}. Error: {}", message.to(), error.getMessage())
-                );
+        return Mono.fromCallable(() -> objectMapper.writeValueAsString(message))
+                .onErrorMap(JsonProcessingException.class, e -> new NotificationSerializationException())
+                .flatMap(json -> send(json, queueUrl))
+                .doOnSuccess(messageId -> log.info("Email notification for {} queued successfully with Message ID: {}", message.to(), messageId))
+                .doOnError(error -> log.error("Failed to send email notification to SQS for recipient: {}. Error: {}", message.to(), error.getMessage()))
+                .then();
     }
 
-    private Mono<String> send(String message) {
-        return Mono.fromCallable(() -> buildRequest(message))
+    @Override
+    public Mono<Void> validateLoanAutomatically(ApplicationRiskEvaluation applicationRiskEvaluation) {
+        log.info("Sending loan validation request to SQS for application [{}] : {}", applicationRiskEvaluation.id(), applicationRiskEvaluation);
+
+        String queueUrl = properties.queueUrl() + properties.loanAutoValidationQueueName();
+
+        return Mono.fromCallable(() -> objectMapper.writeValueAsString(applicationRiskEvaluation))
+                .onErrorMap(JsonProcessingException.class, e -> new LoanSerializationException())
+                .flatMap(json -> send(json, queueUrl))
+                .doOnSuccess(messageId -> log.info("Loan validation queued successfully with Message ID: {}", messageId))
+                .doOnError(error -> log.error("Failed to send loan validation to SQS. Error: {}", error.getMessage()))
+                .then();
+    }
+
+    private Mono<String> send(String message, String queueUrl) {
+        return Mono.fromCallable(() -> buildRequest(message, queueUrl))
                 .flatMap(request -> Mono.fromFuture(client.sendMessage(request)))
                 .doOnNext(response -> log.info("Message sent {}", response.messageId()))
                 .map(SendMessageResponse::messageId);
     }
 
-    private SendMessageRequest buildRequest(String message) {
+    private SendMessageRequest buildRequest(String message, String queueUrl) {
         return SendMessageRequest.builder()
-                .queueUrl(properties.queueUrl())
+                .queueUrl(queueUrl)
                 .messageBody(message)
                 .build();
     }

--- a/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/crediya/sqs/sender/config/SQSSenderProperties.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/crediya/sqs/sender/config/SQSSenderProperties.java
@@ -5,5 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "adapters.sqs")
 public record SQSSenderProperties(
         String region,
-        String queueUrl) {
+        String queueUrl,
+        String loanNotificationQueueName,
+        String loanAutoValidationQueueName) {
 }

--- a/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/crediya/sqs/sender/constants/ErrorMessages.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/crediya/sqs/sender/constants/ErrorMessages.java
@@ -1,0 +1,12 @@
+package co.com.pragma.crediya.sqs.sender.constants;
+
+public final class ErrorMessages {
+
+    private ErrorMessages() {
+    }
+
+    public static final String FAILED_TO_SERIALIZE_NOTIFICATION_MESSAGE = "Failed to serialize notification message";
+
+    public static final String FAILED_TO_SERIALIZE_APPLICATION_RISK_EVALUATION = "Failed to serialize ApplicationRiskEvaluation";
+
+}

--- a/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/crediya/sqs/sender/exceptions/LoanSerializationException.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/crediya/sqs/sender/exceptions/LoanSerializationException.java
@@ -1,0 +1,11 @@
+package co.com.pragma.crediya.sqs.sender.exceptions;
+
+import co.com.pragma.crediya.sqs.sender.constants.ErrorMessages;
+
+public class LoanSerializationException extends RuntimeException {
+
+    public LoanSerializationException() {
+        super(ErrorMessages.FAILED_TO_SERIALIZE_APPLICATION_RISK_EVALUATION);
+    }
+
+}

--- a/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/crediya/sqs/sender/exceptions/NotificationSerializationException.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/crediya/sqs/sender/exceptions/NotificationSerializationException.java
@@ -1,0 +1,12 @@
+package co.com.pragma.crediya.sqs.sender.exceptions;
+
+import co.com.pragma.crediya.sqs.sender.constants.ErrorMessages;
+
+public class NotificationSerializationException extends RuntimeException {
+
+    public NotificationSerializationException() {
+        super(ErrorMessages.FAILED_TO_SERIALIZE_NOTIFICATION_MESSAGE);
+    }
+
+}
+

--- a/infrastructure/driven-adapters/sqs-sender/src/test/java/co/com/pragma/crediya/sqs/sender/SQSSenderTest.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/test/java/co/com/pragma/crediya/sqs/sender/SQSSenderTest.java
@@ -1,7 +1,11 @@
 package co.com.pragma.crediya.sqs.sender;
 
+import co.com.pragma.crediya.model.common.constants.DomainConstants;
+import co.com.pragma.crediya.model.loan.ApplicationRiskEvaluation;
 import co.com.pragma.crediya.model.notification.NotificationMessage;
 import co.com.pragma.crediya.sqs.sender.config.SQSSenderProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,6 +17,9 @@ import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,10 +34,17 @@ class SQSSenderTest {
     @Mock
     private SqsAsyncClient client;
 
+    @Mock
+    private ObjectMapper objectMapper;
+
     @InjectMocks
     private SQSSender sender;
 
-    private static final String QUEUE_URL = "http://queue-url";
+    private static final String QUEUE_URL = "http://queue-url/";
+
+    private static final String LOAN_NOTIFICATION_QUEUE_NAME = "LoanNotification";
+
+    private static final String LOAN_AUTO_VALIDATION_QUEUE_NAME = "LoanAutoValidation";
 
     private static final String EMAIL_TO = "jhondoe@example.com";
 
@@ -48,8 +62,9 @@ class SQSSenderTest {
     }
 
     @Test
-    void sendNotification_successful() {
+    void sendNotification_successful() throws JsonProcessingException {
         when(properties.queueUrl()).thenReturn(QUEUE_URL);
+        when(properties.loanNotificationQueueName()).thenReturn(LOAN_NOTIFICATION_QUEUE_NAME);
 
         SendMessageResponse response = SendMessageResponse.builder()
                 .messageId(MESSAGE_ID)
@@ -58,16 +73,54 @@ class SQSSenderTest {
         when(client.sendMessage(any(SendMessageRequest.class)))
                 .thenReturn(CompletableFuture.completedFuture(response));
 
-        sender.sendNotification(message);
+        when(objectMapper.writeValueAsString(message)).thenReturn("{\"to\":\"" + EMAIL_TO + "\",\"subject\":\"" + SUBJECT + "\",\"body\":\"" + BODY + "\"}");
+
+        sender.sendNotification(message).block();
 
         ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
         verify(client).sendMessage(captor.capture());
 
         SendMessageRequest captured = captor.getValue();
-        assertThat(captured.queueUrl()).isEqualTo(QUEUE_URL);
+        assertThat(captured.queueUrl()).isEqualTo(QUEUE_URL + LOAN_NOTIFICATION_QUEUE_NAME);
         assertThat(captured.messageBody()).contains(EMAIL_TO);
         assertThat(captured.messageBody()).contains(SUBJECT);
         assertThat(captured.messageBody()).contains(BODY);
+    }
+
+    @Test
+    void validateLoanAutomatically_successful() throws JsonProcessingException {
+        UUID applicationId  = UUID.randomUUID();
+        ApplicationRiskEvaluation evaluation = new ApplicationRiskEvaluation(
+                applicationId,
+                DomainConstants.MICROCREDIT,
+                BigDecimal.valueOf(5000000),
+                12,
+                BigDecimal.valueOf(2.08),
+                BigDecimal.valueOf(2000000),
+                List.of()
+        );
+
+        when(properties.queueUrl()).thenReturn(QUEUE_URL);
+        when(properties.loanAutoValidationQueueName()).thenReturn(LOAN_AUTO_VALIDATION_QUEUE_NAME);
+
+        SendMessageResponse response = SendMessageResponse.builder()
+                .messageId(MESSAGE_ID)
+                .build();
+
+        when(client.sendMessage(any(SendMessageRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        String expectedJson = "{\"id\":\"" + applicationId + "\",\"loanType\":\"" + DomainConstants.MICROCREDIT + "\"}";
+        when(objectMapper.writeValueAsString(evaluation)).thenReturn(expectedJson);
+
+        sender.validateLoanAutomatically(evaluation).block();
+
+        ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
+        verify(client).sendMessage(captor.capture());
+
+        SendMessageRequest captured = captor.getValue();
+        assertThat(captured.queueUrl()).isEqualTo(QUEUE_URL + LOAN_AUTO_VALIDATION_QUEUE_NAME);
+        assertThat(captured.messageBody()).isEqualTo(expectedJson);
     }
 
 }

--- a/infrastructure/driven-adapters/sqs-sender/src/test/java/co/com/pragma/crediya/sqs/sender/config/SQSSenderConfigTest.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/test/java/co/com/pragma/crediya/sqs/sender/config/SQSSenderConfigTest.java
@@ -13,14 +13,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SQSSenderConfigTest {
 
     private static final String REGION = "us-east-1";
-    private static final String QUEUE_URL = "http://queue-url";
+
+    private static final String QUEUE_URL = "http://queue-url/";
+
+    private static final String LOAN_NOTIFICATION_QUEUE_NAME = "LoanNotification";
+
+    private static final String LOAN_AUTO_VALIDATION_QUEUE_NAME = "LoanAutoValidation";
 
     @Mock
     private MetricPublisher publisher;
 
     @Test
     void configSqs_shouldCreateClient() {
-        SQSSenderProperties properties = new SQSSenderProperties(REGION, QUEUE_URL);
+        SQSSenderProperties properties = new SQSSenderProperties(REGION, QUEUE_URL, LOAN_NOTIFICATION_QUEUE_NAME, LOAN_AUTO_VALIDATION_QUEUE_NAME);
         SQSSenderConfig config = new SQSSenderConfig();
 
         SqsAsyncClient client = config.configSqs(properties, publisher);

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/exceptions/handler/GlobalExceptionHandler.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/exceptions/handler/GlobalExceptionHandler.java
@@ -3,9 +3,9 @@ package co.com.pragma.crediya.api.exceptions.handler;
 import co.com.pragma.crediya.api.constants.HttpErrorTitles;
 import co.com.pragma.crediya.api.exceptions.*;
 import co.com.pragma.crediya.model.loan.constants.ApplicationFieldNames;
+import co.com.pragma.crediya.model.loan.exceptions.ApplicationBusinessValidationException;
 import co.com.pragma.crediya.model.loan.exceptions.ApplicationCannotBeProcessedException;
 import co.com.pragma.crediya.model.loan.exceptions.ApplicationNotFoundException;
-import co.com.pragma.crediya.model.loan.exceptions.ApplicationValueOutOfBoundsException;
 import co.com.pragma.crediya.model.loan.exceptions.TypeNotFoundException;
 import co.com.pragma.crediya.model.user.exceptions.UserDataInconsistencyException;
 import co.com.pragma.crediya.model.user.exceptions.UserGatewayException;
@@ -74,11 +74,6 @@ public class GlobalExceptionHandler implements ErrorWebExceptionHandler {
             return ProblemDetails.badRequest(HttpErrorTitles.BAD_REQUEST, ex.getMessage());
         }
 
-        if (ex instanceof ApplicationValueOutOfBoundsException) {
-            List<FieldValidationError> errors = List.of(new FieldValidationError(ApplicationFieldNames.AMOUNT, ex.getMessage()));
-            return ProblemDetails.badRequest(HttpErrorTitles.BAD_REQUEST, errors);
-        }
-
         if (ex instanceof ApplicationCannotBeProcessedException) {
             List<FieldValidationError> errors = List.of(new FieldValidationError(ApplicationFieldNames.STATUS, ex.getMessage()));
             return ProblemDetails.badRequest(HttpErrorTitles.BAD_REQUEST, errors);
@@ -86,6 +81,15 @@ public class GlobalExceptionHandler implements ErrorWebExceptionHandler {
 
         if (ex instanceof TypeNotFoundException) {
             List<FieldValidationError> errors = List.of(new FieldValidationError(ApplicationFieldNames.TYPE, ex.getMessage()));
+            return ProblemDetails.badRequest(HttpErrorTitles.BAD_REQUEST, errors);
+        }
+
+        if (ex instanceof ApplicationBusinessValidationException exs) {
+            List<FieldValidationError> errors = exs.getErrors().stream()
+                    .filter(result -> !result.isValid())
+                    .map(result -> new FieldValidationError(result.field(), result.errorMessage()))
+                    .toList();
+
             return ProblemDetails.badRequest(HttpErrorTitles.BAD_REQUEST, errors);
         }
 

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/mapper/LoanApplicationRestMapperTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/mapper/LoanApplicationRestMapperTest.java
@@ -42,7 +42,7 @@ class LoanApplicationRestMapperTest {
 
     @Test
     void toResponse_shouldMapApplicationToLoanApplicationResponse() {
-        Type type = new Type(null, DomainConstants.MICROCREDIT, null, null, null, null);
+        Type type = new Type(null, DomainConstants.MICROCREDIT, null, null, 0, 0, null, null);
         Status status = new Status(null, "APPROVED", null);
         Application application = new Application(UUID.randomUUID(), BigDecimal.valueOf(1000.50), 12, "123456", "jonhdoe@example.com", type, status);
 

--- a/infrastructure/entry-points/sqs-listener/build.gradle
+++ b/infrastructure/entry-points/sqs-listener/build.gradle
@@ -1,0 +1,10 @@
+dependencies {
+    implementation project(':model')
+    implementation project(':usecase')
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'software.amazon.awssdk:sqs'
+    implementation 'org.apache.logging.log4j:log4j-api'
+
+    // ObjectMapper
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+}

--- a/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/crediya/sqs/listener/SQSProcessor.java
+++ b/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/crediya/sqs/listener/SQSProcessor.java
@@ -1,0 +1,32 @@
+package co.com.pragma.crediya.sqs.listener;
+
+import co.com.pragma.crediya.sqs.listener.dto.LoanValidationResponse;
+import co.com.pragma.crediya.usecase.loan.ApplicationUseCase;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+import java.util.function.Function;
+
+@Service
+@RequiredArgsConstructor
+public class SQSProcessor implements Function<Message, Mono<Void>> {
+
+    private final ObjectMapper objectMapper;
+
+    private final ApplicationUseCase applicationUseCase;
+
+    @Override
+    public Mono<Void> apply(Message message) {
+        try {
+            LoanValidationResponse response = objectMapper.readValue(message.body(), LoanValidationResponse.class);
+
+            return applicationUseCase.processApplicationStatusUpdate(response.validation());
+        } catch (Exception e) {
+            return Mono.error(e);
+        }
+    }
+
+}

--- a/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/crediya/sqs/listener/config/SQSConfig.java
+++ b/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/crediya/sqs/listener/config/SQSConfig.java
@@ -1,0 +1,49 @@
+package co.com.pragma.crediya.sqs.listener.config;
+
+import co.com.pragma.crediya.sqs.listener.helper.SQSListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import reactor.core.publisher.Mono;
+import software.amazon.awssdk.auth.credentials.*;
+import software.amazon.awssdk.metrics.MetricPublisher;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.Message;
+
+import java.util.function.Function;
+
+@Configuration
+public class SQSConfig {
+
+    @Bean
+    public SQSListener sqsListener(SqsAsyncClient client, SQSProperties properties, Function<Message, Mono<Void>> fn) {
+        return SQSListener.builder()
+                .client(client)
+                .properties(properties)
+                .processor(fn)
+                .build()
+                .start();
+    }
+
+    @Bean
+    public SqsAsyncClient configSqs(SQSProperties properties, MetricPublisher publisher) {
+        return SqsAsyncClient.builder()
+                .region(Region.of(properties.region()))
+                .overrideConfiguration(o -> o.addMetricPublisher(publisher))
+                .credentialsProvider(getProviderChain())
+                .build();
+    }
+
+    private AwsCredentialsProviderChain getProviderChain() {
+        return AwsCredentialsProviderChain.builder()
+                .addCredentialsProvider(EnvironmentVariableCredentialsProvider.create())
+                .addCredentialsProvider(SystemPropertyCredentialsProvider.create())
+                .addCredentialsProvider(WebIdentityTokenFileCredentialsProvider.create())
+                .addCredentialsProvider(ProfileCredentialsProvider.create())
+                .addCredentialsProvider(ContainerCredentialsProvider.builder().build())
+                .addCredentialsProvider(InstanceProfileCredentialsProvider.create())
+                .build();
+    }
+
+}
+

--- a/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/crediya/sqs/listener/config/SQSProperties.java
+++ b/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/crediya/sqs/listener/config/SQSProperties.java
@@ -1,0 +1,14 @@
+package co.com.pragma.crediya.sqs.listener.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "entrypoint.sqs")
+public record SQSProperties(
+        String region,
+        String queueUrl,
+        String loanValidationResponseQueueName,
+        int waitTimeSeconds,
+        int visibilityTimeoutSeconds,
+        int maxNumberOfMessages,
+        int numberOfThreads) {
+}

--- a/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/crediya/sqs/listener/dto/LoanValidationResponse.java
+++ b/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/crediya/sqs/listener/dto/LoanValidationResponse.java
@@ -1,0 +1,8 @@
+package co.com.pragma.crediya.sqs.listener.dto;
+
+import co.com.pragma.crediya.model.loan.LoanValidation;
+
+public record LoanValidationResponse(
+        String originalMessageId,
+        LoanValidation validation) {
+}

--- a/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/crediya/sqs/listener/helper/SQSListener.java
+++ b/infrastructure/entry-points/sqs-listener/src/main/java/co/com/pragma/crediya/sqs/listener/helper/SQSListener.java
@@ -1,0 +1,90 @@
+package co.com.pragma.crediya.sqs.listener.helper;
+
+import co.com.pragma.crediya.sqs.listener.config.SQSProperties;
+import lombok.Builder;
+import lombok.extern.log4j.Log4j2;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Function;
+
+@Log4j2
+@Builder
+public class SQSListener {
+
+    private final SqsAsyncClient client;
+
+    private final SQSProperties properties;
+
+    private final Function<Message, Mono<Void>> processor;
+
+    private String operation;
+
+    public SQSListener start() {
+        this.operation = "MessageFrom:" + properties.queueUrl();
+
+        ExecutorService service = Executors.newFixedThreadPool(properties.numberOfThreads());
+        Flux<Void> flow = listenRetryRepeat().publishOn(Schedulers.fromExecutorService(service));
+        for (var i = 0; i < properties.numberOfThreads(); i++) {
+            flow.subscribe();
+        }
+
+        return this;
+    }
+
+    private Flux<Void> listenRetryRepeat() {
+        return listen()
+                .doOnError(e -> log.error("Error listening sqs queue", e))
+                .repeat();
+    }
+
+    private Flux<Void> listen() {
+        return getMessages()
+                .flatMap(message -> processor.apply(message)
+                        .name(properties.loanValidationResponseQueueName())
+                        .tag("operation", operation)
+                        .then(confirm(message)))
+                .onErrorContinue((e, o) -> log.error("Error listening sqs message", e));
+    }
+
+    private Mono<Void> confirm(Message message) {
+        String queueUrl = properties.queueUrl() + properties.loanValidationResponseQueueName();
+
+        return Mono.fromCallable(() -> getDeleteMessageRequest(message.receiptHandle(), queueUrl))
+                .flatMap(request -> Mono.fromFuture(client.deleteMessage(request)))
+                .then();
+    }
+
+    private Flux<Message> getMessages() {
+        String queueUrl = properties.queueUrl() + properties.loanValidationResponseQueueName();
+
+        return Mono.fromCallable(() -> getReceiveMessageRequest(queueUrl))
+                .flatMap(request -> Mono.fromFuture(client.receiveMessage(request)))
+                .doOnNext(response -> log.info("{} received messages from sqs", response.messages().size()))
+                .flatMapMany(response -> Flux.fromIterable(response.messages()));
+    }
+
+    private ReceiveMessageRequest getReceiveMessageRequest(String queueUrl) {
+        return ReceiveMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .maxNumberOfMessages(properties.maxNumberOfMessages())
+                .waitTimeSeconds(properties.waitTimeSeconds())
+                .visibilityTimeout(properties.visibilityTimeoutSeconds())
+                .build();
+    }
+
+    private DeleteMessageRequest getDeleteMessageRequest(String receiptHandle, String queueUrl) {
+        return DeleteMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .receiptHandle(receiptHandle)
+                .build();
+    }
+
+}

--- a/infrastructure/entry-points/sqs-listener/src/test/java/co/com/pragma/crediya/sqs/listener/config/SQSConfigTest.java
+++ b/infrastructure/entry-points/sqs-listener/src/test/java/co/com/pragma/crediya/sqs/listener/config/SQSConfigTest.java
@@ -1,0 +1,44 @@
+package co.com.pragma.crediya.sqs.listener.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import reactor.core.publisher.Mono;
+import software.amazon.awssdk.metrics.LoggingMetricPublisher;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SQSConfigTest {
+
+    private static final String REGION = "us-east-1";
+
+    private static final String QUEUE_URL = "http://queue-url/";
+
+    private static final String LOAN_VALIDATION_RESPONSE_QUEUE_NAME = "LoanValidationResponse";
+
+    private SQSConfig sqsConfig;
+
+    private SQSProperties sqsProperties;
+
+    @Mock
+    private SqsAsyncClient sqsAsyncClient;
+
+    @BeforeEach
+    void init() {
+        sqsProperties = new SQSProperties(REGION, QUEUE_URL, LOAN_VALIDATION_RESPONSE_QUEUE_NAME, 20, 10, 10, 1);
+        sqsConfig = new SQSConfig();
+    }
+
+    @Test
+    void configSQSListenerIsNotNull() {
+        assertThat(sqsConfig.sqsListener(sqsAsyncClient, sqsProperties, message -> Mono.empty())).isNotNull();
+    }
+
+    @Test
+    void configSqsIsNotNull() {
+        var loggingMetricPublisher = LoggingMetricPublisher.create();
+        assertThat(sqsConfig.configSqs(sqsProperties, loggingMetricPublisher)).isNotNull();
+    }
+
+}

--- a/infrastructure/entry-points/sqs-listener/src/test/java/co/com/pragma/crediya/sqs/listener/helper/SQSListenerTest.java
+++ b/infrastructure/entry-points/sqs-listener/src/test/java/co/com/pragma/crediya/sqs/listener/helper/SQSListenerTest.java
@@ -1,0 +1,63 @@
+package co.com.pragma.crediya.sqs.listener.helper;
+
+import co.com.pragma.crediya.sqs.listener.config.SQSProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.model.*;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class SQSListenerTest {
+
+    @Mock
+    private SqsAsyncClient asyncClient;
+
+    private SQSProperties sqsProperties;
+
+    @BeforeEach
+    void setUp() {
+        sqsProperties = new SQSProperties(
+                "us-east-1",
+                "http://localhost:4566",
+                "queueName",
+                20,
+                30,
+                10,
+                1
+        );
+
+        var message = Message.builder().body("message").receiptHandle("rh").build();
+        var deleteMessageResponse = DeleteMessageResponse.builder().build();
+        var messageResponse = ReceiveMessageResponse.builder().messages(message).build();
+
+        lenient().when(asyncClient.receiveMessage(any(ReceiveMessageRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(messageResponse));
+        lenient().when(asyncClient.deleteMessage(any(DeleteMessageRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(deleteMessageResponse));
+    }
+
+    @Test
+    void listenerTest() {
+        var sqsListener = SQSListener.builder()
+                .client(asyncClient)
+                .properties(sqsProperties)
+                .processor(msg -> Mono.just(1).then())
+                .build();
+
+        Flux<Void> flow = ReflectionTestUtils.invokeMethod(sqsListener, "listen");
+        StepVerifier.create(flow).verifyComplete();
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -34,3 +34,7 @@ include ':metrics'
 project(':metrics').projectDir = file('./infrastructure/helpers/metrics')
 include ':sqs-sender'
 project(':sqs-sender').projectDir = file('./infrastructure/driven-adapters/sqs-sender')
+include ':sqs-listener'
+project(':sqs-listener').projectDir = file('./infrastructure/entry-points/sqs-listener')
+include ':mustache-template'
+project(':mustache-template').projectDir = file('./infrastructure/driven-adapters/mustache-template')


### PR DESCRIPTION
- Enqueue new loan requests to SQS from Loan Applications microservice if loan type has "automatic_validation" enabled
- Debt Capacity Lambda consumes SQS messages, calculates debt capacity, and publishes results to a result SQS queue
- Java service listens to the result queue and sends email to the applicant with the payment plan, detailing principal and interest per installment
- Update loan application status atomically in database
- Add trace logs for monitoring
- Implement centralized exception handling to avoid exposing unexpected messages
- Replace loan amount and term validations with ValidationLoanApplicationOrchestrator