### PR TITLE
feat(loans): publish loan approved events to SQS

### DIFF
--- a/applications/app-service/src/main/resources/application-local.yaml
+++ b/applications/app-service/src/main/resources/application-local.yaml
@@ -24,6 +24,7 @@ adapters:
     queueUrl: "${AWS_SQS_QUEUE_URL}"
     loanNotificationQueueName: "${AWS_SQS_LOAN_NOTIFICATION_QUEUE_NAME}"
     loanAutoValidationQueueName: "${AWS_SQS_LOAN_AUTO_VALIDATION_QUEUE_NAME}"
+    loanApprovedEventsQueueName: "${AWS_SQS_LOAN_APPROVED_EVENTS_QUEUE_NAME}"
 
 entrypoint:
   sqs:

--- a/applications/app-service/src/test/java/co/com/pragma/crediya/config/UseCasesConfigTest.java
+++ b/applications/app-service/src/test/java/co/com/pragma/crediya/config/UseCasesConfigTest.java
@@ -1,12 +1,9 @@
 package co.com.pragma.crediya.config;
 
 import co.com.pragma.crediya.model.jwt.gateways.JwtProviderPort;
-import co.com.pragma.crediya.model.loan.gateways.ApplicationRepository;
-import co.com.pragma.crediya.model.loan.gateways.LoanValidationPort;
-import co.com.pragma.crediya.model.notification.gateways.NotificationPort;
-import co.com.pragma.crediya.model.loan.gateways.StatusRepository;
-import co.com.pragma.crediya.model.loan.gateways.TypeRepository;
+import co.com.pragma.crediya.model.loan.gateways.*;
 import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
+import co.com.pragma.crediya.model.notification.gateways.NotificationPort;
 import co.com.pragma.crediya.model.notification.gateways.NotificationRendererPort;
 import co.com.pragma.crediya.model.transaction.gateways.TransactionalPort;
 import co.com.pragma.crediya.model.user.gateways.UserPort;
@@ -90,6 +87,11 @@ class UseCasesConfigTest {
         @Bean
         public LoanValidationPort loanValidationPort() {
             return Mockito.mock(LoanValidationPort.class);
+        }
+
+        @Bean
+        public LoanApprovedEventPort loanApprovedEventPort() {
+            return Mockito.mock(LoanApprovedEventPort.class);
         }
 
     }

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/ApprovedApplication.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/ApprovedApplication.java
@@ -1,0 +1,9 @@
+package co.com.pragma.crediya.model.loan;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record ApprovedApplication(
+        UUID id,
+        OffsetDateTime approvedAt) {
+}

--- a/domain/model/src/main/java/co/com/pragma/crediya/model/loan/gateways/LoanApprovedEventPort.java
+++ b/domain/model/src/main/java/co/com/pragma/crediya/model/loan/gateways/LoanApprovedEventPort.java
@@ -1,0 +1,10 @@
+package co.com.pragma.crediya.model.loan.gateways;
+
+import co.com.pragma.crediya.model.loan.ApprovedApplication;
+import reactor.core.publisher.Mono;
+
+public interface LoanApprovedEventPort {
+
+    Mono<Void> sendLoanApprovedEvent(ApprovedApplication approvedApplication);
+
+}

--- a/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/ApplicationUseCase.java
+++ b/domain/usecase/src/main/java/co/com/pragma/crediya/usecase/loan/ApplicationUseCase.java
@@ -8,10 +8,7 @@ import co.com.pragma.crediya.model.loan.*;
 import co.com.pragma.crediya.model.loan.constants.ApplicationConstants;
 import co.com.pragma.crediya.model.loan.constants.ApplicationErrorMessages;
 import co.com.pragma.crediya.model.loan.exceptions.*;
-import co.com.pragma.crediya.model.loan.gateways.ApplicationRepository;
-import co.com.pragma.crediya.model.loan.gateways.LoanValidationPort;
-import co.com.pragma.crediya.model.loan.gateways.StatusRepository;
-import co.com.pragma.crediya.model.loan.gateways.TypeRepository;
+import co.com.pragma.crediya.model.loan.gateways.*;
 import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
 import co.com.pragma.crediya.model.notification.LoanApproval;
 import co.com.pragma.crediya.model.notification.NotificationMessage;
@@ -23,6 +20,7 @@ import co.com.pragma.crediya.usecase.loan.validation.ValidationLoanApplicationOr
 import reactor.core.publisher.Mono;
 
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -30,9 +28,10 @@ public record ApplicationUseCase(TypeRepository typeRepository,
                                  StatusRepository statusRepository,
                                  ApplicationRepository applicationRepository,
                                  ValidationLoanApplicationOrchestrator validationLoanApplicationOrchestrator,
+                                 LoanValidationPort loanValidationPort,
+                                 LoanApprovedEventPort loanApprovedEventPort,
                                  NotificationPort notificationPort,
                                  NotificationRendererPort notificationRendererPort,
-                                 LoanValidationPort loanValidationPort,
                                  LoggerPort logger,
                                  TransactionalPort transactionalPort) {
 
@@ -79,9 +78,18 @@ public record ApplicationUseCase(TypeRepository typeRepository,
                 })
                 .flatMap(this::saveApplication)
                 .as(transactionalPort::transactional)
-                .flatMap(storedApplication ->
-                        sendStatusNotification(storedApplication, storedApplication.status().name())
-                                .thenReturn(storedApplication)
+                .flatMap(storedApplication -> {
+                            if (DomainConstants.APPROVED_STATUS.equalsIgnoreCase(storedApplication.status().name())) {
+                                ApprovedApplication approvedApplication = new ApprovedApplication(storedApplication.id(), OffsetDateTime.now());
+
+                                return loanApprovedEventPort.sendLoanApprovedEvent(approvedApplication)
+                                        .then(sendStatusNotification(storedApplication, storedApplication.status().name()))
+                                        .thenReturn(storedApplication);
+                            }
+
+                            return sendStatusNotification(storedApplication, storedApplication.status().name())
+                                    .thenReturn(storedApplication);
+                        }
                 )
                 .doOnSuccess(storedApplication -> logger.info("Loan application with ID {} updated successfully.", storedApplication.id()))
                 .doOnError(e -> logger.error("Failed to update loan application with ID {}. Reason: {}", id, e.getMessage(), e));
@@ -103,8 +111,11 @@ public record ApplicationUseCase(TypeRepository typeRepository,
                 .flatMap(storedApplication -> {
                     logger.info("Application with ID {} updated to status {}", storedApplication.id(), result.status());
 
-                    if (result.status().equalsIgnoreCase(DomainConstants.APPROVED_STATUS)) {
-                        return sendApprovalNotification(storedApplication, result);
+                    if (DomainConstants.APPROVED_STATUS.equalsIgnoreCase(result.status())) {
+                        ApprovedApplication approvedApplication = new ApprovedApplication(storedApplication.id(), OffsetDateTime.now());
+
+                        return loanApprovedEventPort.sendLoanApprovedEvent(approvedApplication)
+                                .then(sendApprovalNotification(storedApplication, result));
                     }
 
                     return sendStatusNotification(storedApplication, result.status());

--- a/domain/usecase/src/test/java/co/com/pragma/crediya/usecase/loan/ApplicationUseCaseTest.java
+++ b/domain/usecase/src/test/java/co/com/pragma/crediya/usecase/loan/ApplicationUseCaseTest.java
@@ -9,10 +9,7 @@ import co.com.pragma.crediya.model.loan.constants.ApplicationConstants;
 import co.com.pragma.crediya.model.loan.constants.ApplicationErrorMessages;
 import co.com.pragma.crediya.model.loan.constants.ApplicationFieldNames;
 import co.com.pragma.crediya.model.loan.exceptions.*;
-import co.com.pragma.crediya.model.loan.gateways.ApplicationRepository;
-import co.com.pragma.crediya.model.loan.gateways.LoanValidationPort;
-import co.com.pragma.crediya.model.loan.gateways.StatusRepository;
-import co.com.pragma.crediya.model.loan.gateways.TypeRepository;
+import co.com.pragma.crediya.model.loan.gateways.*;
 import co.com.pragma.crediya.model.logs.gateways.LoggerPort;
 import co.com.pragma.crediya.model.notification.LoanApproval;
 import co.com.pragma.crediya.model.notification.NotificationMessage;
@@ -56,13 +53,16 @@ class ApplicationUseCaseTest {
     private ValidationLoanApplicationOrchestrator validationLoanApplicationOrchestrator;
 
     @Mock
+    private LoanValidationPort loanValidationPort;
+
+    @Mock
+    private LoanApprovedEventPort loanApprovedEventPort;
+
+    @Mock
     private NotificationPort notificationPort;
 
     @Mock
     private NotificationRendererPort notificationRendererPort;
-
-    @Mock
-    LoanValidationPort loanValidationPort;
 
     @Mock
     private LoggerPort logger;
@@ -87,7 +87,9 @@ class ApplicationUseCaseTest {
 
     @BeforeEach
     void setUp() {
-        useCase = new ApplicationUseCase(typeRepository, statusRepository, applicationRepository, validationLoanApplicationOrchestrator, notificationPort, notificationRendererPort, loanValidationPort, logger, transactionalPort);
+        useCase = new ApplicationUseCase(
+                typeRepository, statusRepository, applicationRepository, validationLoanApplicationOrchestrator, loanValidationPort,
+                loanApprovedEventPort, notificationPort, notificationRendererPort, logger, transactionalPort);
 
         User loggedUser = new User("1234567890", "jhondoe@example.com", BigDecimal.valueOf(1200000));
 
@@ -270,6 +272,8 @@ class ApplicationUseCaseTest {
 
         when(applicationRepository.save(any(Application.class))).thenReturn(Mono.just(application));
 
+        when(loanApprovedEventPort.sendLoanApprovedEvent(any(ApprovedApplication.class))).thenReturn(Mono.empty());
+
         when(notificationPort.sendNotification(any(NotificationMessage.class))).thenReturn(Mono.empty());
 
         StepVerifier.create(useCase.processAndApproveOrReject(appId, newStatus))
@@ -395,6 +399,8 @@ class ApplicationUseCaseTest {
         when(typeRepository.findById(application.type().id())).thenReturn(Mono.just(type));
 
         when(applicationRepository.save(any(Application.class))).thenReturn(Mono.just(application));
+
+        when(loanApprovedEventPort.sendLoanApprovedEvent(any(ApprovedApplication.class))).thenReturn(Mono.empty());
 
         when(notificationPort.sendNotification(any(NotificationMessage.class))).thenReturn(Mono.empty());
 

--- a/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/crediya/sqs/sender/SQSSender.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/crediya/sqs/sender/SQSSender.java
@@ -1,10 +1,13 @@
 package co.com.pragma.crediya.sqs.sender;
 
 import co.com.pragma.crediya.model.loan.ApplicationRiskEvaluation;
+import co.com.pragma.crediya.model.loan.ApprovedApplication;
+import co.com.pragma.crediya.model.loan.gateways.LoanApprovedEventPort;
 import co.com.pragma.crediya.model.loan.gateways.LoanValidationPort;
 import co.com.pragma.crediya.model.notification.NotificationMessage;
 import co.com.pragma.crediya.model.notification.gateways.NotificationPort;
 import co.com.pragma.crediya.sqs.sender.config.SQSSenderProperties;
+import co.com.pragma.crediya.sqs.sender.exceptions.LoanApprovedEventSerializationException;
 import co.com.pragma.crediya.sqs.sender.exceptions.LoanSerializationException;
 import co.com.pragma.crediya.sqs.sender.exceptions.NotificationSerializationException;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -20,7 +23,7 @@ import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 @Service
 @Log4j2
 @RequiredArgsConstructor
-public class SQSSender implements NotificationPort, LoanValidationPort {
+public class SQSSender implements NotificationPort, LoanValidationPort, LoanApprovedEventPort {
 
     private final SQSSenderProperties properties;
 
@@ -51,8 +54,22 @@ public class SQSSender implements NotificationPort, LoanValidationPort {
         return Mono.fromCallable(() -> objectMapper.writeValueAsString(applicationRiskEvaluation))
                 .onErrorMap(JsonProcessingException.class, e -> new LoanSerializationException())
                 .flatMap(json -> send(json, queueUrl))
-                .doOnSuccess(messageId -> log.info("Loan validation queued successfully with Message ID: {}", messageId))
-                .doOnError(error -> log.error("Failed to send loan validation to SQS. Error: {}", error.getMessage()))
+                .doOnSuccess(messageId -> log.info("Loan validation for application [{}] queued successfully with Message ID: {}", applicationRiskEvaluation.id(), messageId))
+                .doOnError(error -> log.error("Failed to send loan validation to SQS for application [{}]. Error: {}", applicationRiskEvaluation.id(), error.getMessage()))
+                .then();
+    }
+
+    @Override
+    public Mono<Void> sendLoanApprovedEvent(ApprovedApplication approvedApplication) {
+        log.info("Sending loan approved event to SQS for application [{}] : {}", approvedApplication.id(), approvedApplication);
+
+        String queueUrl = properties.queueUrl() + properties.loanApprovedEventsQueueName();
+
+        return Mono.fromCallable(() -> objectMapper.writeValueAsString(approvedApplication))
+                .onErrorMap(JsonProcessingException.class, e -> new LoanApprovedEventSerializationException())
+                .flatMap(json -> send(json, queueUrl))
+                .doOnSuccess(messageId -> log.info("Loan approved event for application [{}] queued successfully with Message ID: {}", approvedApplication.id(), messageId))
+                .doOnError(error -> log.error("Failed to send loan approved event to SQS for application [{}]. Error: {}", approvedApplication.id(), error.getMessage()))
                 .then();
     }
 

--- a/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/crediya/sqs/sender/config/SQSSenderProperties.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/crediya/sqs/sender/config/SQSSenderProperties.java
@@ -7,5 +7,6 @@ public record SQSSenderProperties(
         String region,
         String queueUrl,
         String loanNotificationQueueName,
-        String loanAutoValidationQueueName) {
+        String loanAutoValidationQueueName,
+        String loanApprovedEventsQueueName) {
 }

--- a/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/crediya/sqs/sender/constants/ErrorMessages.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/crediya/sqs/sender/constants/ErrorMessages.java
@@ -9,4 +9,6 @@ public final class ErrorMessages {
 
     public static final String FAILED_TO_SERIALIZE_APPLICATION_RISK_EVALUATION = "Failed to serialize ApplicationRiskEvaluation";
 
+    public static final String FAILED_TO_SERIALIZE_LOAN_APPROVED_EVENT = "Failed to serialize LoanApprovedEvent";
+
 }

--- a/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/crediya/sqs/sender/exceptions/LoanApprovedEventSerializationException.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/main/java/co/com/pragma/crediya/sqs/sender/exceptions/LoanApprovedEventSerializationException.java
@@ -1,0 +1,11 @@
+package co.com.pragma.crediya.sqs.sender.exceptions;
+
+import co.com.pragma.crediya.sqs.sender.constants.ErrorMessages;
+
+public class LoanApprovedEventSerializationException extends RuntimeException {
+
+    public LoanApprovedEventSerializationException() {
+        super(ErrorMessages.FAILED_TO_SERIALIZE_LOAN_APPROVED_EVENT);
+    }
+
+}

--- a/infrastructure/driven-adapters/sqs-sender/src/test/java/co/com/pragma/crediya/sqs/sender/SQSSenderTest.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/test/java/co/com/pragma/crediya/sqs/sender/SQSSenderTest.java
@@ -2,6 +2,7 @@ package co.com.pragma.crediya.sqs.sender;
 
 import co.com.pragma.crediya.model.common.constants.DomainConstants;
 import co.com.pragma.crediya.model.loan.ApplicationRiskEvaluation;
+import co.com.pragma.crediya.model.loan.ApprovedApplication;
 import co.com.pragma.crediya.model.notification.NotificationMessage;
 import co.com.pragma.crediya.sqs.sender.config.SQSSenderProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -18,6 +19,7 @@ import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -46,6 +48,8 @@ class SQSSenderTest {
 
     private static final String LOAN_AUTO_VALIDATION_QUEUE_NAME = "LoanAutoValidation";
 
+    private static final String LOAN_APPROVED_EVENTS_QUEUE_NAME = "LoanApprovedEvents";
+
     private static final String EMAIL_TO = "jhondoe@example.com";
 
     private static final String SUBJECT = "Subject";
@@ -62,7 +66,7 @@ class SQSSenderTest {
     }
 
     @Test
-    void sendNotification_successful() throws JsonProcessingException {
+    void sendNotificationSuccessful() throws JsonProcessingException {
         when(properties.queueUrl()).thenReturn(QUEUE_URL);
         when(properties.loanNotificationQueueName()).thenReturn(LOAN_NOTIFICATION_QUEUE_NAME);
 
@@ -88,8 +92,8 @@ class SQSSenderTest {
     }
 
     @Test
-    void validateLoanAutomatically_successful() throws JsonProcessingException {
-        UUID applicationId  = UUID.randomUUID();
+    void validateLoanAutomaticallySuccessful() throws JsonProcessingException {
+        UUID applicationId = UUID.randomUUID();
         ApplicationRiskEvaluation evaluation = new ApplicationRiskEvaluation(
                 applicationId,
                 DomainConstants.MICROCREDIT,
@@ -120,6 +124,33 @@ class SQSSenderTest {
 
         SendMessageRequest captured = captor.getValue();
         assertThat(captured.queueUrl()).isEqualTo(QUEUE_URL + LOAN_AUTO_VALIDATION_QUEUE_NAME);
+        assertThat(captured.messageBody()).isEqualTo(expectedJson);
+    }
+
+    @Test
+    void sendLoanApprovedEventSuccessful() throws JsonProcessingException {
+        ApprovedApplication approvedApplication = new ApprovedApplication(UUID.randomUUID(), OffsetDateTime.now());
+
+        when(properties.queueUrl()).thenReturn(QUEUE_URL);
+        when(properties.loanApprovedEventsQueueName()).thenReturn(LOAN_APPROVED_EVENTS_QUEUE_NAME);
+
+        SendMessageResponse response = SendMessageResponse.builder()
+                .messageId(MESSAGE_ID)
+                .build();
+
+        when(client.sendMessage(any(SendMessageRequest.class)))
+                .thenReturn(CompletableFuture.completedFuture(response));
+
+        String expectedJson = "{\"id\":\"" + approvedApplication.id() + "\",\"approvedAt\":\"" + approvedApplication.approvedAt().toString() + "\"}";
+        when(objectMapper.writeValueAsString(approvedApplication)).thenReturn(expectedJson);
+
+        sender.sendLoanApprovedEvent(approvedApplication).block();
+
+        ArgumentCaptor<SendMessageRequest> captor = ArgumentCaptor.forClass(SendMessageRequest.class);
+        verify(client).sendMessage(captor.capture());
+
+        SendMessageRequest captured = captor.getValue();
+        assertThat(captured.queueUrl()).isEqualTo(QUEUE_URL + LOAN_APPROVED_EVENTS_QUEUE_NAME);
         assertThat(captured.messageBody()).isEqualTo(expectedJson);
     }
 

--- a/infrastructure/driven-adapters/sqs-sender/src/test/java/co/com/pragma/crediya/sqs/sender/config/SQSSenderConfigTest.java
+++ b/infrastructure/driven-adapters/sqs-sender/src/test/java/co/com/pragma/crediya/sqs/sender/config/SQSSenderConfigTest.java
@@ -20,12 +20,15 @@ class SQSSenderConfigTest {
 
     private static final String LOAN_AUTO_VALIDATION_QUEUE_NAME = "LoanAutoValidation";
 
+    private static final String LOAN_APPROVED_EVENTS_QUEUE_NAME = "LoanApprovedEvents";
+
     @Mock
     private MetricPublisher publisher;
 
     @Test
     void configSqs_shouldCreateClient() {
-        SQSSenderProperties properties = new SQSSenderProperties(REGION, QUEUE_URL, LOAN_NOTIFICATION_QUEUE_NAME, LOAN_AUTO_VALIDATION_QUEUE_NAME);
+        SQSSenderProperties properties = new SQSSenderProperties(
+                REGION, QUEUE_URL, LOAN_NOTIFICATION_QUEUE_NAME, LOAN_AUTO_VALIDATION_QUEUE_NAME, LOAN_APPROVED_EVENTS_QUEUE_NAME);
         SQSSenderConfig config = new SQSSenderConfig();
 
         SqsAsyncClient client = config.configSqs(properties, publisher);


### PR DESCRIPTION
- Add ApprovedApplication domain model
- Define LoanApprovedEventPort in domain
- Extend ApplicationUseCase to publish LoanApprovedEvent when a loan is approved
- Update ApplicationUseCase tests to mock LoanApprovedEventPort
- Implement LoanApprovedEventPort in SQSSender
- Add new queue configuration loanApprovedEventsQueueName in SQSSenderProperties and application-local.yaml
- Add SQSSender unit tests for loan approved event publishing
- Update SQSSenderConfigTest with new property
- Ensure trace logs for sending loan approved events