### PR TITLE
feat(loans): apply unified base path for loan applications module

### DIFF
--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -14,6 +14,7 @@ server:
 management:
   endpoints:
     web:
+      base-path: "/api/v1/loan-applications/actuator"
       exposure:
         include: "health,prometheus"
   endpoint:
@@ -25,5 +26,7 @@ cors:
   allowed-origins: "${CORS_ALLOWED_ORIGINS}"
 
 springdoc:
+  api-docs:
+    path: "/api/v1/loan-applications/api-docs"
   swagger-ui:
-    path: "/swagger-ui.html"
+    path: "/api/v1/loan-applications/swagger-ui.html"

--- a/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/pragma/crediya/consumer/UserServiceClient.java
+++ b/infrastructure/driven-adapters/rest-consumer/src/main/java/co/com/pragma/crediya/consumer/UserServiceClient.java
@@ -33,7 +33,7 @@ public class UserServiceClient implements UserPort {
 
         return webClient
                 .post()
-                .uri("/api/v1/users/search")
+                .uri("/auth/users/search")
                 .bodyValue(request)
                 .retrieve()
                 .onStatus(

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/RouterRest.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/RouterRest.java
@@ -31,7 +31,7 @@ public class RouterRest {
     @Bean
     @RouterOperations({
             @RouterOperation(
-                    path = ApiConstants.LOAN_APPLICATIONS_PATH,
+                    path = ApiConstants.BASE_PATH,
                     produces = {MediaType.APPLICATION_JSON_VALUE},
                     method = RequestMethod.GET,
                     beanClass = LoanApplicationHandler.class,
@@ -72,7 +72,7 @@ public class RouterRest {
                     )
             ),
             @RouterOperation(
-                    path = ApiConstants.LOAN_APPLICATIONS_PATH,
+                    path = ApiConstants.BASE_PATH,
                     produces = {MediaType.APPLICATION_JSON_VALUE},
                     method = RequestMethod.POST,
                     beanClass = LoanApplicationHandler.class,
@@ -156,8 +156,8 @@ public class RouterRest {
     })
     public RouterFunction<ServerResponse> routerFunction(LoanApplicationHandler handler) {
         return RouterFunctions.route()
-                .GET(ApiConstants.LOAN_APPLICATIONS_PATH, handler::getReport)
-                .POST(ApiConstants.LOAN_APPLICATIONS_PATH, handler::createLoanApplication)
+                .GET(ApiConstants.BASE_PATH, handler::getReport)
+                .POST(ApiConstants.BASE_PATH, handler::createLoanApplication)
                 .PATCH(ApiConstants.UPDATE_LOAN_STATUS_PATH, handler::updateStatus)
                 .build();
     }

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/config/security/SecurityConfig.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/config/security/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
                 .authorizeExchange(exchangeSpec -> exchangeSpec
                         .pathMatchers(ApiConstants.PUBLIC_PATTERNS)
                         .permitAll()
-                        .pathMatchers(HttpMethod.GET, ApiConstants.LOAN_APPLICATIONS_PATH)
+                        .pathMatchers(HttpMethod.GET, ApiConstants.BASE_PATH)
                         .hasAnyAuthority(
                                 DomainConstants.ADVISOR_ROLE
                         )
@@ -37,7 +37,7 @@ public class SecurityConfig {
                         .hasAnyAuthority(
                                 DomainConstants.ADVISOR_ROLE
                         )
-                        .pathMatchers(HttpMethod.POST, ApiConstants.LOAN_APPLICATIONS_PATH)
+                        .pathMatchers(HttpMethod.POST, ApiConstants.BASE_PATH)
                         .hasAnyAuthority(
                                 DomainConstants.CUSTOMER_ROLE
                         )

--- a/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/constants/ApiConstants.java
+++ b/infrastructure/entry-points/reactive-web/src/main/java/co/com/pragma/crediya/api/constants/ApiConstants.java
@@ -9,17 +9,17 @@ public final class ApiConstants {
 
     public static final String API_V1 = "/api/v1";
 
-    public static final String LOAN_APPLICATIONS_PATH = API_V1 + "/loan-applications";
+    public static final String BASE_PATH = API_V1 + "/loan-applications";
 
-    public static final String UPDATE_LOAN_STATUS_PATH = LOAN_APPLICATIONS_PATH + "/{" + ApplicationFieldNames.ID + "}/status";
+    public static final String UPDATE_LOAN_STATUS_PATH = BASE_PATH + "/{" + ApplicationFieldNames.ID + "}/status";
 
     public static final String[] PUBLIC_PATTERNS = {
-            "/actuator",
-            "/actuator/health",
-            "/actuator/prometheus",
-            "/v3/api-docs/**",
-            "/swagger-ui/**",
-            "/swagger-ui.html"
+            BASE_PATH + "/actuator",
+            BASE_PATH + "/actuator/health",
+            BASE_PATH + "/actuator/prometheus",
+            BASE_PATH + "/swagger-ui.html",
+            BASE_PATH + "/swagger-ui/**",
+            BASE_PATH + "/api-docs/**"
     };
 
     public static final String BEARER_PREFIX = "Bearer ";

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/RouterRestTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/RouterRestTest.java
@@ -135,7 +135,7 @@ class RouterRestTest {
     @Test
     void createLoanApplication_shouldReturnCreated_whenValidRequest() {
         webTestClient.post()
-                .uri(ApiConstants.LOAN_APPLICATIONS_PATH)
+                .uri(ApiConstants.BASE_PATH)
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(request)
@@ -155,7 +155,7 @@ class RouterRestTest {
     @Test
     void createLoanApplication_shouldReturnError_whenBodyEmpty() {
         webTestClient.post()
-                .uri(ApiConstants.LOAN_APPLICATIONS_PATH)
+                .uri(ApiConstants.BASE_PATH)
                 .accept(MediaType.APPLICATION_JSON)
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue("")

--- a/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/config/ConfigTest.java
+++ b/infrastructure/entry-points/reactive-web/src/test/java/co/com/pragma/crediya/api/config/ConfigTest.java
@@ -91,7 +91,7 @@ class ConfigTest {
     @Test
     void corsConfigurationShouldAllowOrigins() {
         webTestClient.post()
-                .uri(ApiConstants.LOAN_APPLICATIONS_PATH)
+                .uri(ApiConstants.BASE_PATH)
                 .exchange()
                 .expectStatus().isBadRequest()
                 .expectHeader().valueEquals("Content-Security-Policy",


### PR DESCRIPTION
- Define BASE_PATH constant (/api/v1/loan-applications) in ApiConstants
- Replace LOAN_APPLICATIONS_PATH references with BASE_PATH across router and security configuration
- Update application.yaml to use BASE_PATH for actuator, OpenAPI docs and Swagger UI
- Adjust PUBLIC_PATTERNS to include BASE_PATH for actuator, swagger and api-docs endpoints
- Update UserServiceClient to call /auth/users/search instead of /api/v1/users/search